### PR TITLE
MarketFactory have better emits Event instead of return value.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,11 @@
 				"expect": "readonly",
 				"it": "readonly",
 				"artifacts": "readonly",
-				"contract": "readonly"
+				"contract": "readonly",
+				"beforeEach": "readonly",
+				"before": "readonly",
+				"afterEach": "readonly",
+				"after": "readonly"
 			}
 		},
 		{

--- a/contracts/MarketFactory.sol
+++ b/contracts/MarketFactory.sol
@@ -4,10 +4,12 @@ import "./UseState.sol";
 import "./Market.sol";
 
 contract MarketFactory is UseState {
+	event Create(address indexed _from, address _market);
+
 	function createMarket(address _addr) public returns (address) {
 		Market market = new Market(_addr, false);
 		address marketAddr = address(market);
 		addMarket(marketAddr);
-		return marketAddr;
+		emit Create(msg.sender, marketAddr);
 	}
 }

--- a/test/market-factory.ts
+++ b/test/market-factory.ts
@@ -1,7 +1,47 @@
-contract('MarketFactory', () => {
-	describe('createMarket', () => {
-		it('Create a new Market Contract')
+import {
+	MarketFactoryInstance,
+	StateTestInstance,
+	MarketInstance
+} from '../types/truffle-contracts'
 
-		it('Adds a new Market Contract address to State Contract')
+contract('MarketFactory', ([deployer, u1]) => {
+	const marketFactoryContract = artifacts.require('MarketFactory')
+	const marketContract = artifacts.require('Market')
+	const stateContract = artifacts.require('StateTest')
+
+	describe('createMarket', () => {
+		var marketFactory: MarketFactoryInstance
+		var state: StateTestInstance
+		var expectedMarketAddress: any
+		var deployedMarket: MarketInstance
+
+		beforeEach(async () => {
+			state = await stateContract.new({from: deployer})
+			marketFactory = await marketFactoryContract.new({from: deployer})
+			await state.setMarketFactory(marketFactory.address, {from: deployer})
+			await marketFactory.changeStateAddress(state.address, {from: deployer})
+
+			const result = await marketFactory.createMarket(u1, {from: deployer})
+
+			expectedMarketAddress = await result.logs.filter(
+				e => e.event === 'Create'
+			)[0].args._market
+		})
+
+		it('Create a new Market Contract and emit Create Event telling created market address', async () => {
+			// eslint-disable-next-line @typescript-eslint/await-thenable
+			deployedMarket = await marketContract.at(expectedMarketAddress)
+			const behaviorAddress = await deployedMarket.behavior({from: deployer})
+
+			expect(behaviorAddress).to.be.equal(u1)
+		})
+
+		it('Adds a new Market Contract address to State Contract', async () => {
+			const isContained = await state.containsMarket(expectedMarketAddress, {
+				from: deployer
+			})
+
+			expect(isContained).to.be.equal(true)
+		})
 	})
 })


### PR DESCRIPTION
# Description

I changed how to return Market address from 'return' to emitting Event.

# Why

Contract function that writes to state have better emits Event instead of return some value.

# Code

- [x] I ran `npm run lint`

# Dev Challenge

Entry to [Dev Challenge](https://github.com/dev-protocol/repository-token/blob/master/docs/DEV_CHALLENGE.md).

- [x] I entry to Dev Challenge with this pull request
- [ ] I don't enter to Dev Challenge with this pull request

If you enter, please edit the following sections.

## Address

0x656b243D73911edAee87779125fEF90c2b1d781f

## Severity

During the Dev Challenge, you can receive Dev tokens depending on the severity of this pull request. Please select one of your expectations.

- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low
- [ ] Note

_Severity and example are:_

| Severity | Points | e.g.                                                                                              |
| -------- | ------ | ------------------------------------------------------------------------------------------------- |
| Critical | 100    | Update token model, Update the core of this software.                                             |
| High     | 50     | Fix vulnerability, Make the Developer Rewards Program better, etc.; Fix or Kaizen unknown issues. |
| Medium   | 20     | Add implementation, Fix test, Refactoring, etc.; Fix to follow whitepaper.                        |
| Low      | 4      | Empty test, Rename variable, etc.; Fix without implementation.                                    |
| Note     | 1      | Typo, Sentence mistakes, etc.; Fix not related to software.                                       |

When you fix an issue reported by others, severity points are divided by the following ratio:

| Reporter | Resolver |
| -------- | -------- |
| 20%      | 80%      |

# Related Issues

Fixes # .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
