### PR TITLE
PropertyFactory have better emits Event instead of return value.

### DIFF
--- a/contracts/PropertyFactory.sol
+++ b/contracts/PropertyFactory.sol
@@ -6,6 +6,8 @@ contract PropertyFactory is UseState {
 	uint8 decimals = 18;
 	uint256 supply = 10000000;
 
+	event Create(address indexed _from, address _property);
+
 	function createProperty(string memory _name, string memory _symbol)
 		public
 		returns (address)
@@ -18,6 +20,7 @@ contract PropertyFactory is UseState {
 			supply
 		);
 		addProperty(address(property));
+		emit Create(msg.sender, address(property));
 		return address(property);
 	}
 }

--- a/test/property-factory.ts
+++ b/test/property-factory.ts
@@ -1,8 +1,50 @@
-contract('PropertyFactory', () => {
+import {
+	PropertyInstance,
+	PropertyFactoryInstance,
+	StateTestInstance
+} from '../types/truffle-contracts'
+
+contract('PropertyFactory', ([deployer, u1]) => {
+	const propertyFactoryContract = artifacts.require('PropertyFactory')
+	const propertyContract = artifacts.require('Property')
+	const stateContract = artifacts.require('StateTest')
+
 	describe('createProperty', () => {
-		it(
-			'Create a new Property Contract and emit Create Event telling created property address'
-		)
+		var propertyFactory: PropertyFactoryInstance
+		var state: StateTestInstance
+		var expectedPropertyAddress: any
+		var deployedProperty: PropertyInstance
+
+		beforeEach(async () => {
+			state = await stateContract.new({from: deployer})
+			propertyFactory = await propertyFactoryContract.new({from: deployer})
+			await state.setPropertyFactory(propertyFactory.address, {from: deployer})
+			await propertyFactory.changeStateAddress(state.address, {from: deployer})
+
+			const result = await propertyFactory.createProperty('sample', 'SAMPLE', {
+				from: deployer
+			})
+
+			expectedPropertyAddress = await result.logs.filter(
+				e => e.event === 'Create'
+			)[0].args._property
+		})
+
+		it('Create a new Property Contract and emit Create Event telling created property address', async () => {
+			// eslint-disable-next-line @typescript-eslint/await-thenable
+			deployedProperty = await propertyContract.at(expectedPropertyAddress)
+			const owner = await deployedProperty._owner({from: deployer})
+			const name = await deployedProperty.name({from: deployer})
+			const symbol = await deployedProperty.symbol({from: deployer})
+			const decimals = await deployedProperty.decimals({from: deployer})
+			const totalSupply = await deployedProperty.totalSupply({from: deployer})
+
+			expect(owner).to.be.equal(deployer)
+			expect(name).to.be.equal('sample')
+			expect(symbol).to.be.equal('SAMPLE')
+			expect(decimals.toNumber()).to.be.equal(18)
+			expect(totalSupply.toNumber()).to.be.equal(10000000)
+		})
 
 		it('Adds a new Property Contract address to State Contract')
 	})

--- a/test/property-factory.ts
+++ b/test/property-factory.ts
@@ -1,6 +1,8 @@
 contract('PropertyFactory', () => {
 	describe('createProperty', () => {
-		it('Create a new Property Contract')
+		it(
+			'Create a new Property Contract and emit Create Event telling created property address'
+		)
 
 		it('Adds a new Property Contract address to State Contract')
 	})

--- a/test/property-factory.ts
+++ b/test/property-factory.ts
@@ -46,6 +46,12 @@ contract('PropertyFactory', ([deployer, u1]) => {
 			expect(totalSupply.toNumber()).to.be.equal(10000000)
 		})
 
-		it('Adds a new Property Contract address to State Contract')
+		it('Adds a new Property Contract address to State Contract', async () => {
+			const isProperty = await state.isProperty(expectedPropertyAddress, {
+				from: deployer
+			})
+
+			expect(isProperty).to.be.equal(true)
+		})
 	})
 })

--- a/test/property-factory.ts
+++ b/test/property-factory.ts
@@ -4,7 +4,7 @@ import {
 	StateTestInstance
 } from '../types/truffle-contracts'
 
-contract('PropertyFactory', ([deployer, u1]) => {
+contract('PropertyFactory', ([deployer]) => {
 	const propertyFactoryContract = artifacts.require('PropertyFactory')
 	const propertyContract = artifacts.require('Property')
 	const stateContract = artifacts.require('StateTest')


### PR DESCRIPTION
# Description

I changed how to return Property address from 'return' to emitting Event.

# Why

Contract function that writes to state have better emits Event instead of return some value.

# Code

- [x] I ran `npm run lint`

# Dev Challenge

Entry to [Dev Challenge](https://github.com/dev-protocol/repository-token/blob/master/docs/DEV_CHALLENGE.md).

- [x] I entry to Dev Challenge with this pull request
- [ ] I don't enter to Dev Challenge with this pull request

If you enter, please edit the following sections.

## Address

0x656b243D73911edAee87779125fEF90c2b1d781f

## Severity

During the Dev Challenge, you can receive Dev tokens depending on the severity of this pull request. Please select one of your expectations.

- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low
- [ ] Note

_Severity and example are:_

| Severity | Points | e.g.                                                                                              |
| -------- | ------ | ------------------------------------------------------------------------------------------------- |
| Critical | 100    | Update token model, Update the core of this software.                                             |
| High     | 50     | Fix vulnerability, Make the Developer Rewards Program better, etc.; Fix or Kaizen unknown issues. |
| Medium   | 20     | Add implementation, Fix test, Refactoring, etc.; Fix to follow whitepaper.                        |
| Low      | 4      | Empty test, Rename variable, etc.; Fix without implementation.                                    |
| Note     | 1      | Typo, Sentence mistakes, etc.; Fix not related to software.                                       |

When you fix an issue reported by others, severity points are divided by the following ratio:

| Reporter | Resolver |
| -------- | -------- |
| 20%      | 80%      |

# Related Issues

Fixes # .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
