### PR TITLE
Change node version in the Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 'node'
+  - 10


### PR DESCRIPTION
# Description

Travis CI was not working due to a skippable build error.

This problem can be solved by changing the Node version in the Travis CI to 10.

# Why

Required for a correct CI/CD pipeline.

# Dev Challenge

Entry to [Dev Challenge](https://github.com/dev-protocol/repository-token/blob/master/docs/DEV_CHALLENGE.md).

- [ ] I entry to Dev Challenge with this pull request
- [x] I don't enter to Dev Challenge with this pull request

# Related Issues

Fixes #41 .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
