### PR TITLE
use delegatecall

### DIFF
--- a/contracts/Allocator.sol
+++ b/contracts/Allocator.sol
@@ -10,7 +10,6 @@ import "./Market.sol";
 import "./Metrics.sol";
 import "./UseState.sol";
 import "./LastAllocationTime.sol";
-import "./DevLockUp.sol";
 
 contract Allocator is Killable, Ownable, UseState, Withdrawable {
 	using SafeMath for uint256;
@@ -25,11 +24,9 @@ contract Allocator is Killable, Ownable, UseState, Withdrawable {
 	mapping(address => bool) pendingIncrements;
 	uint256 public mintPerBlock;
 	LastAllocationTime private lastAllocationTime;
-	DevLockUp private devLockUp;
 
 	constructor() public {
 		lastAllocationTime = new LastAllocationTime();
-		devLockUp = new DevLockUp();
 	}
 
 	modifier onlyProperty(address _addr) {
@@ -112,31 +109,5 @@ contract Allocator is Killable, Ownable, UseState, Withdrawable {
 	{
 		ERC20Burnable(getToken()).burnFrom(msg.sender, _amount);
 		increment(_property, _amount);
-	}
-
-	function lockUp(address propertyAddress, uint256 amount) public {
-		// solium-disable-next-line security/no-low-level-calls
-		(bool success, ) = address(devLockUp).delegatecall(
-			abi.encodeWithSignature(
-				"lockUp(address,address,uint256)",
-				msg.sender,
-				propertyAddress,
-				amount
-			)
-		);
-		require(success, "lockup was failed.");
-	}
-
-	function cancel(address propertyAddress) public {
-		// solium-disable-next-line security/no-low-level-calls
-		(bool success, ) = address(devLockUp).delegatecall(
-			abi.encodeWithSignature(
-				"cancel(address,address)",
-				msg.sender,
-				propertyAddress,
-				propertyAddress
-			)
-		);
-		require(success, "cancel was failed.");
 	}
 }

--- a/contracts/Allocator.sol
+++ b/contracts/Allocator.sol
@@ -117,16 +117,26 @@ contract Allocator is Killable, Ownable, UseState, Withdrawable {
 	function lockUp(address propertyAddress, uint256 amount) public {
 		// solium-disable-next-line security/no-low-level-calls
 		(bool success, ) = address(devLockUp).delegatecall(
-			abi.encodeWithSignature("lockUp(address,address,uint256)", msg.sender, propertyAddress, amount)
+			abi.encodeWithSignature(
+				"lockUp(address,address,uint256)",
+				msg.sender,
+				propertyAddress,
+				amount
+			)
 		);
-		require(success,"lockup was failed.");
+		require(success, "lockup was failed.");
 	}
 
 	function cancel(address propertyAddress) public {
 		// solium-disable-next-line security/no-low-level-calls
 		(bool success, ) = address(devLockUp).delegatecall(
-			abi.encodeWithSignature("cancel(address,address)", msg.sender, propertyAddress, propertyAddress)
+			abi.encodeWithSignature(
+				"cancel(address,address)",
+				msg.sender,
+				propertyAddress,
+				propertyAddress
+			)
 		);
-		require(success,"cancel was failed.");
+		require(success, "cancel was failed.");
 	}
 }

--- a/contracts/Allocator.sol
+++ b/contracts/Allocator.sol
@@ -115,10 +115,18 @@ contract Allocator is Killable, Ownable, UseState, Withdrawable {
 	}
 
 	function lockUp(address propertyAddress, uint256 amount) public {
-		devLockUp.lockUp(propertyAddress, amount);
+		// solium-disable-next-line security/no-low-level-calls
+		(bool success, ) = address(devLockUp).delegatecall(
+			abi.encodeWithSignature("lockUp(address,address,uint256)", msg.sender, propertyAddress, amount)
+		);
+		require(success,"lockup was failed.");
 	}
 
 	function cancel(address propertyAddress) public {
-		devLockUp.cancel(propertyAddress);
+		// solium-disable-next-line security/no-low-level-calls
+		(bool success, ) = address(devLockUp).delegatecall(
+			abi.encodeWithSignature("cancel(address,address)", msg.sender, propertyAddress, propertyAddress)
+		);
+		require(success,"cancel was failed.");
 	}
 }

--- a/contracts/DevLockUp.sol
+++ b/contracts/DevLockUp.sol
@@ -16,15 +16,15 @@ contract DevLockUp is UseState {
 		releasedBlockNumber = new ReleasedBlockNumber();
 	}
 
-	function lockUp(address fromAddress, address propertyAddress, uint256 value)
+	function lockUp(address propertyAddress, uint256 value)
 		public
 	{
 		require(
-			canceledFlg.isCanceled(fromAddress, propertyAddress) == false,
+			canceledFlg.isCanceled(msg.sender, propertyAddress) == false,
 			"lock up is already canceled"
 		);
 		ERC20 devToken = ERC20(getToken());
-		uint256 balance = devToken.balanceOf(fromAddress);
+		uint256 balance = devToken.balanceOf(msg.sender);
 		require(value <= balance, "insufficient balance");
 		// solium-disable-next-line security/no-low-level-calls
 		(bool success, bytes memory data) = address(devToken).delegatecall(
@@ -36,22 +36,22 @@ contract DevLockUp is UseState {
 		);
 		require(success, "transfer was failed.");
 		require(abi.decode(data, (bool)), "transfer was failed.");
-		devValue.set(fromAddress, propertyAddress, value);
+		devValue.set(msg.sender, propertyAddress, value);
 	}
 
-	function cancel(address fromAddress, address propertyAddress) public {
+	function cancel(address propertyAddress) public {
 		require(
-			devValue.hasTokenByProperty(fromAddress, propertyAddress),
+			devValue.hasTokenByProperty(msg.sender, propertyAddress),
 			"dev token is not locked"
 		);
 		require(
-			canceledFlg.isCanceled(fromAddress, propertyAddress) == false,
+			canceledFlg.isCanceled(msg.sender, propertyAddress) == false,
 			"lock up is already canceled"
 		);
 		// TODO after withdrawal, allow the flag to be set again
-		canceledFlg.setCancelFlg(fromAddress, propertyAddress);
+		canceledFlg.setCancelFlg(msg.sender, propertyAddress);
 		// TODO get wait block number from polisy contract
-		releasedBlockNumber.setBlockNumber(fromAddress, propertyAddress, 10);
+		releasedBlockNumber.setBlockNumber(msg.sender, propertyAddress, 10);
 	}
 }
 

--- a/contracts/DevLockUp.sol
+++ b/contracts/DevLockUp.sol
@@ -16,9 +16,7 @@ contract DevLockUp is UseState {
 		releasedBlockNumber = new ReleasedBlockNumber();
 	}
 
-	function lockUp(address propertyAddress, uint256 value)
-		public
-	{
+	function lockUp(address propertyAddress, uint256 value) public {
 		require(
 			canceledFlg.isCanceled(msg.sender, propertyAddress) == false,
 			"lock up is already canceled"

--- a/contracts/DevLockUp.sol
+++ b/contracts/DevLockUp.sol
@@ -16,66 +16,71 @@ contract DevLockUp is UseState {
 		releasedBlockNumber = new ReleasedBlockNumber();
 	}
 
-	function lockUp(address propertyAddress, uint256 value) public {
+	function lockUp(address fromAddress, address propertyAddress, uint256 value) public {
 		require(
-			canceledFlg.isCanceled(propertyAddress) == false,
+			canceledFlg.isCanceled(fromAddress, propertyAddress) == false,
 			"lock up is already canceled"
 		);
 		ERC20 devToken = ERC20(getToken());
-		uint256 balance = devToken.balanceOf(msg.sender);
+		uint256 balance = devToken.balanceOf(fromAddress);
 		require(value <= balance, "insufficient balance");
-		devToken.transfer(propertyAddress, value);
-		devValue.set(propertyAddress, value);
+		// solium-disable-next-line security/no-low-level-calls
+		(bool success, bytes memory data) = address(devToken).delegatecall(
+			abi.encodeWithSignature("transfer(address,uint256)", propertyAddress, value)
+		);
+		require(success,"transfer was failed.");
+		require(abi.decode(data, (bool)),"transfer was failed.");
+		devValue.set(fromAddress, propertyAddress, value);
 	}
 
-	function cancel(address propertyAddress) public {
+	function cancel(address fromAddress, address propertyAddress) public {
 		require(
-			devValue.hasTokenByProperty(propertyAddress),
+			devValue.hasTokenByProperty(fromAddress, propertyAddress),
 			"dev token is not locked"
 		);
 		require(
-			canceledFlg.isCanceled(propertyAddress) == false,
+			canceledFlg.isCanceled(fromAddress, propertyAddress) == false,
 			"lock up is already canceled"
 		);
 		// TODO after withdrawal, allow the flag to be set again
-		canceledFlg.setCancelFlg(propertyAddress);
+		canceledFlg.setCancelFlg(fromAddress, propertyAddress);
 		// TODO get wait block number from polisy contract
-		releasedBlockNumber.setBlockNumber(propertyAddress, 10);
+		releasedBlockNumber.setBlockNumber(fromAddress, propertyAddress, 10);
 	}
 }
 
 contract DevValue {
 	using SafeMath for uint256;
 	mapping(address => mapping(address => uint256)) private _lockUpedDevValue;
-	function set(address propertyAddress, uint256 value) public {
-		_lockUpedDevValue[msg.sender][propertyAddress] =
-			_lockUpedDevValue[msg.sender][propertyAddress] +
+	function set(address fromAddress, address propertyAddress, uint256 value) public {
+		_lockUpedDevValue[fromAddress][propertyAddress] =
+			_lockUpedDevValue[fromAddress][propertyAddress] +
 			value;
 	}
 
-	function hasTokenByProperty(address propertyAddress)
+	function hasTokenByProperty(address fromAddress, address propertyAddress)
 		public
 		view
 		returns (bool)
 	{
-		return _lockUpedDevValue[msg.sender][propertyAddress] != 0;
+		return _lockUpedDevValue[fromAddress][propertyAddress] != 0;
 	}
 }
 
 contract CanceledLockUpFlg {
 	mapping(address => mapping(address => bool)) private _canceled;
-	function setCancelFlg(address propertyAddress) public {
-		_canceled[msg.sender][propertyAddress] = true;
+	function setCancelFlg(address fromAddress, address propertyAddress) public {
+		_canceled[fromAddress][propertyAddress] = true;
 	}
-	function isCanceled(address propertyAddress) public view returns (bool) {
-		return _canceled[msg.sender][propertyAddress];
+	function isCanceled(address fromAddress, address propertyAddress) public view returns (bool) {
+		return _canceled[fromAddress][propertyAddress];
 	}
 }
 
 contract ReleasedBlockNumber {
 	using SafeMath for uint256;
 	mapping(address => mapping(address => uint256)) private _released;
-	function setBlockNumber(address propertyAddress, uint256 wait) public {
-		_released[msg.sender][propertyAddress] = block.number + wait;
+	function setBlockNumber(address fromAddress, address propertyAddress, uint256 wait) public {
+		_released[fromAddress][propertyAddress] = block.number + wait;
 	}
 }

--- a/contracts/DevLockUp.sol
+++ b/contracts/DevLockUp.sol
@@ -16,7 +16,9 @@ contract DevLockUp is UseState {
 		releasedBlockNumber = new ReleasedBlockNumber();
 	}
 
-	function lockUp(address fromAddress, address propertyAddress, uint256 value) public {
+	function lockUp(address fromAddress, address propertyAddress, uint256 value)
+		public
+	{
 		require(
 			canceledFlg.isCanceled(fromAddress, propertyAddress) == false,
 			"lock up is already canceled"
@@ -26,10 +28,14 @@ contract DevLockUp is UseState {
 		require(value <= balance, "insufficient balance");
 		// solium-disable-next-line security/no-low-level-calls
 		(bool success, bytes memory data) = address(devToken).delegatecall(
-			abi.encodeWithSignature("transfer(address,uint256)", propertyAddress, value)
+			abi.encodeWithSignature(
+				"transfer(address,uint256)",
+				propertyAddress,
+				value
+			)
 		);
-		require(success,"transfer was failed.");
-		require(abi.decode(data, (bool)),"transfer was failed.");
+		require(success, "transfer was failed.");
+		require(abi.decode(data, (bool)), "transfer was failed.");
 		devValue.set(fromAddress, propertyAddress, value);
 	}
 
@@ -52,7 +58,9 @@ contract DevLockUp is UseState {
 contract DevValue {
 	using SafeMath for uint256;
 	mapping(address => mapping(address => uint256)) private _lockUpedDevValue;
-	function set(address fromAddress, address propertyAddress, uint256 value) public {
+	function set(address fromAddress, address propertyAddress, uint256 value)
+		public
+	{
 		_lockUpedDevValue[fromAddress][propertyAddress] =
 			_lockUpedDevValue[fromAddress][propertyAddress] +
 			value;
@@ -72,7 +80,11 @@ contract CanceledLockUpFlg {
 	function setCancelFlg(address fromAddress, address propertyAddress) public {
 		_canceled[fromAddress][propertyAddress] = true;
 	}
-	function isCanceled(address fromAddress, address propertyAddress) public view returns (bool) {
+	function isCanceled(address fromAddress, address propertyAddress)
+		public
+		view
+		returns (bool)
+	{
 		return _canceled[fromAddress][propertyAddress];
 	}
 }
@@ -80,7 +92,11 @@ contract CanceledLockUpFlg {
 contract ReleasedBlockNumber {
 	using SafeMath for uint256;
 	mapping(address => mapping(address => uint256)) private _released;
-	function setBlockNumber(address fromAddress, address propertyAddress, uint256 wait) public {
+	function setBlockNumber(
+		address fromAddress,
+		address propertyAddress,
+		uint256 wait
+	) public {
 		_released[fromAddress][propertyAddress] = block.number + wait;
 	}
 }

--- a/contracts/LockUp.sol
+++ b/contracts/LockUp.sol
@@ -4,14 +4,14 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./UseState.sol";
 
-contract DevLockUp is UseState {
+contract LockUp is UseState {
 	using SafeMath for uint256;
-	DevValue private devValue;
+	TokenValue private tokenValue;
 	CanceledLockUpFlg private canceledFlg;
 	ReleasedBlockNumber private releasedBlockNumber;
 
 	constructor() public {
-		devValue = new DevValue();
+		tokenValue = new TokenValue();
 		canceledFlg = new CanceledLockUpFlg();
 		releasedBlockNumber = new ReleasedBlockNumber();
 	}
@@ -34,12 +34,12 @@ contract DevLockUp is UseState {
 		);
 		require(success, "transfer was failed.");
 		require(abi.decode(data, (bool)), "transfer was failed.");
-		devValue.set(msg.sender, propertyAddress, value);
+		tokenValue.set(msg.sender, propertyAddress, value);
 	}
 
 	function cancel(address propertyAddress) public {
 		require(
-			devValue.hasTokenByProperty(msg.sender, propertyAddress),
+			tokenValue.hasTokenByProperty(msg.sender, propertyAddress),
 			"dev token is not locked"
 		);
 		require(
@@ -53,7 +53,7 @@ contract DevLockUp is UseState {
 	}
 }
 
-contract DevValue {
+contract TokenValue {
 	using SafeMath for uint256;
 	mapping(address => mapping(address => uint256)) private _lockUpedDevValue;
 	function set(address fromAddress, address propertyAddress, uint256 value)

--- a/contracts/Property.sol
+++ b/contracts/Property.sol
@@ -27,14 +27,4 @@ contract Property is ERC20, ERC20Detailed, UseState {
 		_transfer(msg.sender, _to, _value);
 		return true;
 	}
-
-	function lockUp(uint256 value) public returns (bool) {
-		Allocator(allocator()).lockUp(address(this), value);
-		return true;
-	}
-
-	function cancel() public returns (bool) {
-		Allocator(allocator()).cancel(address(this));
-		return true;
-	}
 }

--- a/test/dev-lock-file.ts
+++ b/test/dev-lock-file.ts
@@ -1,14 +1,20 @@
-contract('DevLockUpTest', () => {
+contract('DevValueTest', () => {
 	const DevValueContract = artifacts.require('DevValue')
 	describe('DevValueTest; hasTokenByProperty', () => {
 		it('has token by property', async () => {
 			const devValue = await DevValueContract.new()
-			await devValue.set('0xA717AA5E8858cA5836Fef082E6B2965ba0dB615d', 10)
+			await devValue.set(
+				'0x2d6ab242bc13445954ac46e4eaa7bfa6c7aca167',
+				'0xA717AA5E8858cA5836Fef082E6B2965ba0dB615d',
+				10
+			)
 			let result = await devValue.hasTokenByProperty(
+				'0x2d6ab242bc13445954ac46e4eaa7bfa6c7aca167',
 				'0xA717AA5E8858cA5836Fef082E6B2965ba0dB615d'
 			)
 			expect(result).to.be.equal(true)
 			result = await devValue.hasTokenByProperty(
+				'0x2d6ab242bc13445954ac46e4eaa7bfa6c7aca167',
 				'0x32A5598b078Ad20287f210803a6ad5D96C8df1d1'
 			)
 			expect(result).to.be.equal(false)
@@ -21,12 +27,17 @@ contract('CanceledLockUpFlgTest', () => {
 	describe('CanceledLockUpFlgTest; isCanceled', () => {
 		it('is canceled', async () => {
 			const canceled = await CanceledLockUpFlgContract.new()
-			await canceled.setCancelFlg('0xA717AA5E8858cA5836Fef082E6B2965ba0dB615d')
+			await canceled.setCancelFlg(
+				'0x2d6ab242bc13445954ac46e4eaa7bfa6c7aca167',
+				'0xA717AA5E8858cA5836Fef082E6B2965ba0dB615d'
+			)
 			let result = await canceled.isCanceled(
+				'0x2d6ab242bc13445954ac46e4eaa7bfa6c7aca167',
 				'0xA717AA5E8858cA5836Fef082E6B2965ba0dB615d'
 			)
 			expect(result).to.be.equal(true)
 			result = await canceled.isCanceled(
+				'0x2d6ab242bc13445954ac46e4eaa7bfa6c7aca167',
 				'0x32A5598b078Ad20287f210803a6ad5D96C8df1d1'
 			)
 			expect(result).to.be.equal(false)
@@ -42,6 +53,7 @@ contract('ReleasedBlockNumberTest', () => {
 			// eslint-disable-next-line no-warning-comments
 			// TODO assert
 			await canceled.setBlockNumber(
+				'0x2d6ab242bc13445954ac46e4eaa7bfa6c7aca167',
 				'0xA717AA5E8858cA5836Fef082E6B2965ba0dB615d',
 				30
 			)

--- a/test/lock-up.ts
+++ b/test/lock-up.ts
@@ -1,19 +1,19 @@
-contract('DevValueTest', () => {
-	const DevValueContract = artifacts.require('DevValue')
-	describe('DevValueTest; hasTokenByProperty', () => {
+contract('TokenValueTest', () => {
+	const TokenValueContract = artifacts.require('TokenValue')
+	describe('TokenValueTest; hasTokenByProperty', () => {
 		it('has token by property', async () => {
-			const devValue = await DevValueContract.new()
-			await devValue.set(
+			const tokenValue = await TokenValueContract.new()
+			await tokenValue.set(
 				'0x2d6ab242bc13445954ac46e4eaa7bfa6c7aca167',
 				'0xA717AA5E8858cA5836Fef082E6B2965ba0dB615d',
 				10
 			)
-			let result = await devValue.hasTokenByProperty(
+			let result = await tokenValue.hasTokenByProperty(
 				'0x2d6ab242bc13445954ac46e4eaa7bfa6c7aca167',
 				'0xA717AA5E8858cA5836Fef082E6B2965ba0dB615d'
 			)
 			expect(result).to.be.equal(true)
-			result = await devValue.hasTokenByProperty(
+			result = await tokenValue.hasTokenByProperty(
 				'0x2d6ab242bc13445954ac46e4eaa7bfa6c7aca167',
 				'0x32A5598b078Ad20287f210803a6ad5D96C8df1d1'
 			)


### PR DESCRIPTION
# Description

enabled to use msg.sender of ERC20 contract by using delegatecall

# Why

Since msg.sender is not the execution address, the address of the contract caller is set
