### PR TITLE
delete unnecessary function and test

### DIFF
--- a/contracts/Allocator.sol
+++ b/contracts/Allocator.sol
@@ -18,10 +18,8 @@ contract Allocator is Killable, Ownable, UseState, Withdrawable {
 	mapping(address => uint256) lastAllocationValueEachMetrics;
 	uint256 public lastTotalAllocationValuePerBlock;
 
-	uint256 public initialPaymentBlock;
-	uint256 public lastPaymentBlock;
-	uint256 public totalPaymentValue;
 	mapping(address => bool) pendingIncrements;
+	// TODO not set
 	uint256 public mintPerBlock;
 	LastAllocationTime private lastAllocationTime;
 
@@ -39,22 +37,6 @@ contract Allocator is Killable, Ownable, UseState, Withdrawable {
 
 	function setSecondsPerBlock(uint256 _sec) public onlyOwner {
 		lastAllocationTime.setSecondsPerBlock(_sec);
-	}
-
-	function updateAllocateValue(uint256 _value) public {
-		address prop = msg.sender;
-		require(isProperty(prop), "Is't Property Contract");
-		totalPaymentValue += _value;
-		uint256 totalPaymentsPerBlock = totalPaymentValue /
-			(block.number - initialPaymentBlock);
-		uint256 lastPaymentPerBlock = _value /
-			(block.number - lastPaymentBlock);
-		uint256 acceleration = lastPaymentPerBlock / totalPaymentsPerBlock;
-		mintPerBlock = totalPaymentsPerBlock * acceleration;
-
-		if (_value > 0) {
-			lastPaymentBlock = block.number;
-		}
 	}
 
 	function allocate(address _metrics) public payable {
@@ -101,13 +83,5 @@ contract Allocator is Killable, Ownable, UseState, Withdrawable {
 		lastTotalAllocationValuePerBlock = nextTotalAllocationValuePerBlock;
 		increment(property, allocation);
 		delete pendingIncrements[_metrics];
-	}
-
-	function investToProperty(address _property, uint256 _amount)
-		public
-		onlyProperty(_property)
-	{
-		ERC20Burnable(getToken()).burnFrom(msg.sender, _amount);
-		increment(_property, _amount);
 	}
 }

--- a/test/allocator.ts
+++ b/test/allocator.ts
@@ -1,16 +1,4 @@
-import {
-	StateInstance,
-	DummyDEVInstance,
-	AllocatorTestInstance,
-	PropertyInstance
-} from '../types/truffle-contracts'
-
-contract('Allocator', ([deployer, u1]) => {
-	const allocatorContract = artifacts.require('AllocatorTest')
-	const dummyDEVContract = artifacts.require('DummyDEV')
-	const stateContract = artifacts.require('StateTest')
-	const propertyContract = artifacts.require('Property')
-
+contract('Allocator', () => {
 	describe('allocate', () => {
 		it("Calls Market Contract's calculate function mapped to Metrics Contract")
 
@@ -121,82 +109,5 @@ contract('Allocator', ([deployer, u1]) => {
 		it(
 			'Should fail to destruct this contract when sent from the non-owner account'
 		)
-	})
-
-	describe('invest', () => {
-		var dummyDEV: DummyDEVInstance
-		var state: StateInstance
-		var allocator: AllocatorTestInstance
-		var property: PropertyInstance
-
-		beforeEach(async () => {
-			dummyDEV = await dummyDEVContract.new('Dev', 'DEV', 18, 10000, {
-				from: deployer
-			})
-
-			state = await stateContract.new({from: deployer})
-			await state.setToken(dummyDEV.address, {from: deployer})
-			await state.setPropertyFactory(deployer, {from: deployer})
-
-			property = await propertyContract.new(
-				deployer,
-				'test',
-				'TEST',
-				18,
-				1000,
-				{
-					from: deployer
-				}
-			)
-			await state.addProperty(property.address, {from: deployer})
-
-			allocator = await allocatorContract.new({from: deployer})
-			await allocator.changeStateAddress(state.address, {from: deployer})
-
-			await dummyDEV.approve(allocator.address, 10000, {from: deployer})
-		})
-
-		it('Sender burns the self specified number of DEVs', async () => {
-			await allocator.investToProperty(property.address, 100, {from: deployer})
-			const ownedDEVs = await dummyDEV.balanceOf(deployer, {from: deployer})
-			expect(ownedDEVs.toNumber()).to.be.equal(9900)
-		})
-
-		it('The number of DEVs burned by the sender is added to the withdrawal amount', async () => {
-			await allocator.investToProperty(property.address, 10000, {
-				from: deployer
-			})
-
-			const withdrawTotal = await allocator.getTotal(property.address, {
-				from: deployer
-			})
-
-			const withdrawPrice = await allocator.getPrice(property.address, {
-				from: deployer
-			})
-
-			expect(withdrawTotal.toNumber()).to.be.equal(10000)
-			expect(withdrawPrice.toNumber()).to.be.equal(10)
-		})
-
-		it(
-			'Should fail to payment when sent from other than a smart-contract address'
-		)
-
-		it('Should fail to specify address except Property Contract address', async () => {
-			const result = await allocator
-				.investToProperty(u1, 100, {from: deployer})
-				.catch((err: Error) => err)
-
-			expect(result).to.instanceOf(Error)
-		})
-
-		it('Should fail to payment when Sender try to send more DEVs than Sender owned DEVs', async () => {
-			const result = await allocator
-				.investToProperty(property.address, 2000000000, {from: deployer})
-				.catch((err: Error) => err)
-
-			expect(result).to.instanceOf(Error)
-		})
 	})
 })


### PR DESCRIPTION
# Description

#61 

# Why

decide the mintPerBlock with Policy Contract, so the updateAllocateValue and investToProperty method in Allocator is no longer needed.

# supplement

I also remove test cases that used the deleted function.