### PR TITLE
Rename methods to more intuitive naming

### DIFF
--- a/contracts/libs/Decimals.sol
+++ b/contracts/libs/Decimals.sol
@@ -5,7 +5,7 @@ library Decimals {
 		return 1000000000000000000;
 	}
 
-	function ratioInto(uint256 _a, uint256 _b)
+	function outOf(uint256 _a, uint256 _b)
 		internal
 		pure
 		returns (uint256 result, uint256 basis)
@@ -15,17 +15,18 @@ library Decimals {
 		return ((_a * numerator) / (_b * base), base);
 	}
 
-	function percentOf(uint256 _a, uint256 _b)
+	function multipliedBy(uint256 _a, uint256 _b, uint256 _decimals)
 		internal
 		pure
 		returns (uint256 result, uint256 basis)
 	{
+		uint256 decimals = _decimals > 0 ? _decimals : 1;
 		uint256 base = _basis();
 		uint256 numerator = base * base;
 		uint256 primaryNumerator = numerator * base;
 		return (
 			(_a * primaryNumerator) / ((_a * numerator) / (_b * base) / _a),
-			base * 100000000000000000000
+			base * base * decimals
 		);
 	}
 }

--- a/contracts/libs/Decimals.sol
+++ b/contracts/libs/Decimals.sol
@@ -14,19 +14,4 @@ library Decimals {
 		uint256 numerator = base * base;
 		return ((_a * numerator) / (_b * base), base);
 	}
-
-	function multipliedBy(uint256 _a, uint256 _b, uint256 _decimals)
-		internal
-		pure
-		returns (uint256 result, uint256 basis)
-	{
-		uint256 decimals = _decimals > 0 ? _decimals : 1;
-		uint256 base = _basis();
-		uint256 numerator = base * base;
-		uint256 primaryNumerator = numerator * base;
-		return (
-			(_a * primaryNumerator) / ((_a * numerator) / (_b * base) / _a),
-			base * base * decimals
-		);
-	}
 }

--- a/contracts/libs/Decimals.test.sol
+++ b/contracts/libs/Decimals.test.sol
@@ -5,19 +5,19 @@ import "./Decimals.sol";
 contract DecimalsTest {
 	using Decimals for uint256;
 
-	function ratioInto(uint256 _a, uint256 _b)
+	function outOf(uint256 _a, uint256 _b)
 		public
 		pure
 		returns (uint256 result, uint256 basis)
 	{
-		return _a.ratioInto(_b);
+		return _a.outOf(_b);
 	}
 
-	function percentOf(uint256 _a, uint256 _b)
+	function multipliedBy(uint256 _a, uint256 _b, uint256 _decimals)
 		public
 		pure
 		returns (uint256 result, uint256 basis)
 	{
-		return _a.percentOf(_b);
+		return _a.multipliedBy(_b, _decimals);
 	}
 }

--- a/contracts/libs/Decimals.test.sol
+++ b/contracts/libs/Decimals.test.sol
@@ -12,12 +12,4 @@ contract DecimalsTest {
 	{
 		return _a.outOf(_b);
 	}
-
-	function multipliedBy(uint256 _a, uint256 _b, uint256 _decimals)
-		public
-		pure
-		returns (uint256 result, uint256 basis)
-	{
-		return _a.multipliedBy(_b, _decimals);
-	}
 }

--- a/test/libs/decimals.ts
+++ b/test/libs/decimals.ts
@@ -1,11 +1,11 @@
 contract('Decimals', ([deployer]) => {
 	const decimalsTestContract = artifacts.require('DecimalsTest')
-	describe('ratioInto', () => {
-		it('ratioInto returns ratio into between two numbers', async () => {
+	describe('outOf', () => {
+		it('outOf returns ratio of the first args out of second args', async () => {
 			const decimalsTest = await decimalsTestContract.new({
 				from: deployer
 			})
-			const {0: resultBN, 1: basisBN} = await decimalsTest.ratioInto(28, 70)
+			const {0: resultBN, 1: basisBN} = await decimalsTest.outOf(28, 70)
 			const result = Number(resultBN.toString())
 			const basis = Number(basisBN.toString())
 			const answer = 28 / 70
@@ -13,12 +13,19 @@ contract('Decimals', ([deployer]) => {
 		})
 	})
 
-	describe('percentOf', () => {
-		it('percentOf returns first agrs percent of second args', async () => {
+	describe('multipliedBy', () => {
+		it('multipliedBy returns result of maybe includes decimals calculation between two numbers', async () => {
 			const decimalsTest = await decimalsTestContract.new({
 				from: deployer
 			})
-			const {0: resultBN, 1: basisBN} = await decimalsTest.percentOf(70, 40)
+			const a = 70
+			const b = 0.4
+			const decimals = 10
+			const {0: resultBN, 1: basisBN} = await decimalsTest.multipliedBy(
+				a,
+				b * decimals,
+				decimals
+			)
 			const result = Number(resultBN.toString())
 			const basis = Number(basisBN.toString())
 			const answer = 70 * 0.4

--- a/test/libs/decimals.ts
+++ b/test/libs/decimals.ts
@@ -12,24 +12,4 @@ contract('Decimals', ([deployer]) => {
 			expect(result / basis).to.be.equal(answer)
 		})
 	})
-
-	describe('multipliedBy', () => {
-		it('multipliedBy returns result of maybe includes decimals calculation between two numbers', async () => {
-			const decimalsTest = await decimalsTestContract.new({
-				from: deployer
-			})
-			const a = 70
-			const b = 0.4
-			const decimals = 10
-			const {0: resultBN, 1: basisBN} = await decimalsTest.multipliedBy(
-				a,
-				b * decimals,
-				decimals
-			)
-			const result = Number(resultBN.toString())
-			const basis = Number(basisBN.toString())
-			const answer = 70 * 0.4
-			expect(result / basis).to.be.equal(answer)
-		})
-	})
 })


### PR DESCRIPTION
# Description

- Made calculation library methods that may include decimals more intuitive.
- A new option can control the number of decimals.

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
