### PR TITLE
67 market vote

### DIFF
--- a/contracts/src/Lockup.sol
+++ b/contracts/src/Lockup.sol
@@ -4,6 +4,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./libs/Utils.sol";
 import "./policy/PolicyFactory.sol";
+import "./property/Property.sol";
 import "./property/PropertyGroup.sol";
 import "./config/UsingConfig.sol";
 

--- a/contracts/src/market/Market.sol
+++ b/contracts/src/market/Market.sol
@@ -40,20 +40,25 @@ contract Market is UsingConfig {
 	bool public enabled;
 	address public behavior;
 	uint256 public issuedMetrics;
-	uint256 public totalVotes;
 	uint256 private _votingEndBlockNumber;
+	uint256 private _agreeCount;
+	uint256 private _oppositeCount;
 
 	modifier onlyDisabledMarket() {
 		require(enabled == false, "market is already enabled");
+		require(
+			block.number <= _votingEndBlockNumber,
+			"voting deadline is over"
+		);
 		_;
 	}
 
-	constructor(address _config, address _behavior, bool _enabled)
-		public
+	constructor(address _config, address _behavior)
+		public onlyMarketFactory
 		UsingConfig(_config)
 	{
 		behavior = _behavior;
-		enabled = _enabled;
+		enabled = false;
 		uint256 marketVotingBlocks = Policy(config().policy())
 			.marketVotingBlocks();
 		_votingEndBlockNumber = block.number + marketVotingBlocks;
@@ -99,19 +104,19 @@ contract Market is UsingConfig {
 	 * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20Burnable.sol
 	 * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol
 	 */
-	function vote(uint256 _tokenNumber) public onlyDisabledMarket {
-		require(
-			block.number <= _votingEndBlockNumber,
-			"voting deadline is over"
-		);
+	function vote(uint256 _tokenValue, bool _agree) public onlyDisabledMarket {
 		// TODO count vote
 		// https://github.com/dev-protocol/protocol/blob/master/docs/WHITEPAPER.JA.md#abstentionpenalty
-		ERC20Burnable(config().token()).burnFrom(msg.sender, _tokenNumber);
-		totalVotes = totalVotes + _tokenNumber;
-		uint256 DEVtotalSupply = ERC20Burnable(config().token()).totalSupply();
-		if (totalVotes >= DEVtotalSupply.div(10)) {
-			enabled = true;
+		ERC20Burnable(config().token()).burnFrom(msg.sender, _tokenValue);
+		if (_agree) {
+			_agreeCount += _tokenValue;
+		} else {
+			_oppositeCount += _tokenValue;
 		}
+		enabled = Policy(config().policy()).marketApproval(
+			_agreeCount,
+			_oppositeCount
+		);
 	}
 
 	function authenticatedCallback(address _prop) public returns (address) {

--- a/contracts/src/market/Market.sol
+++ b/contracts/src/market/Market.sol
@@ -54,7 +54,8 @@ contract Market is UsingConfig {
 	}
 
 	constructor(address _config, address _behavior)
-		public onlyMarketFactory
+		public
+		onlyMarketFactory
 		UsingConfig(_config)
 	{
 		behavior = _behavior;

--- a/contracts/src/market/MarketFactory.sol
+++ b/contracts/src/market/MarketFactory.sol
@@ -10,9 +10,10 @@ contract MarketFactory is UsingConfig {
 	constructor(address _config) public UsingConfig(_config) {}
 
 	function createMarket(address _addr) public returns (address) {
-		Market market = new Market(address(config()), _addr, false);
+		Market market = new Market(address(config()), _addr);
 		address marketAddr = address(market);
 		MarketGroup(config().marketGroup()).addMarket(marketAddr);
 		emit Create(msg.sender, marketAddr);
+		return marketAddr;
 	}
 }

--- a/test/market/market-factory.ts
+++ b/test/market/market-factory.ts
@@ -41,7 +41,6 @@ contract('MarketFactoryTest', ([deployer, u1]) => {
 		})
 
 		it('Create a new Market Contract and emit Create Event telling created market address', async () => {
-			// eslint-disable-next-line @typescript-eslint/await-thenable
 			deployedMarket = await marketContract.at(expectedMarketAddress)
 			const behaviorAddress = await deployedMarket.behavior({from: deployer})
 

--- a/test/market/market.ts
+++ b/test/market/market.ts
@@ -1,5 +1,7 @@
-contract('MarketTest', ([deployer, u1]) => {
+contract('MarketTest', ([deployer, behavior]) => {
 	const marketContract = artifacts.require('merket/Market')
+	const marketFactoryContract = artifacts.require('market/MarketFactory')
+	const marketGroupContract = artifacts.require('market/MarketGroup')
 	const dummyDEVContract = artifacts.require('DummyDEV')
 	const addressConfigContract = artifacts.require('config/AddressConfig')
 	const policyContract = artifacts.require('policy/PolicyTest')
@@ -38,17 +40,30 @@ contract('MarketTest', ([deployer, u1]) => {
 	})
 
 	describe('Market; vote', () => {
+		let marketFactory: any
+		let marketGroup: any
 		let dummyDEV: any
 		let market: any
 		let addressConfig: any
 		let policy: any
 		let policyFactory: any
+		let expectedMarketAddress: any
 		beforeEach(async () => {
 			dummyDEV = await dummyDEVContract.new('Dev', 'DEV', 18, 10000, {
 				from: deployer
 			})
 			addressConfig = await addressConfigContract.new({from: deployer})
 			await addressConfig.setToken(dummyDEV.address, {from: deployer})
+			marketFactory = await marketFactoryContract.new(addressConfig.address, {
+				from: deployer
+			})
+			marketGroup = await marketGroupContract.new(addressConfig.address, {
+				from: deployer
+			})
+			await addressConfig.setMarketFactory(marketFactory.address, {
+				from: deployer
+			})
+			await addressConfig.setMarketGroup(marketGroup.address, {from: deployer})
 			policy = await policyContract.new({from: deployer})
 			policyFactory = await policyFactoryContract.new(addressConfig.address, {
 				from: deployer
@@ -57,28 +72,17 @@ contract('MarketTest', ([deployer, u1]) => {
 				from: deployer
 			})
 			await policyFactory.createPolicy(policy.address)
+			const result = await marketFactory.createMarket(behavior)
+			expectedMarketAddress = await result.logs.filter(
+				(e: {event: string}) => e.event === 'Create'
+			)[0].args._market
+			market = await marketContract.at(expectedMarketAddress)
 		})
 
-		it('Vote as a positive vote, votes are the number of sent DEVs', async () => {
-			market = await marketContract.new(addressConfig.address, u1, false, {
-				from: deployer
-			})
-			await dummyDEV.approve(market.address, 40, {from: deployer})
-
-			await market.vote(10, {from: deployer})
-			const firstTotalVotes = await market.totalVotes({from: deployer})
-
-			expect(firstTotalVotes.toNumber()).to.be.equal(10)
-
-			await market.vote(20, {from: deployer})
-			const secondTotalVotes = await market.totalVotes({from: deployer})
-			expect(secondTotalVotes.toNumber()).to.be.equal(30)
-		})
+		it('Total value of votes for and against, votes are the number of sent DEVs', async () => {})
+		it('Creating a market contract from other than a factory results in an error', async () => {})
 
 		it('When total votes for more than 10% of the total supply of DEV are obtained, this Market Contract is enabled', async () => {
-			market = await marketContract.new(addressConfig.address, u1, false, {
-				from: deployer
-			})
 			await dummyDEV.approve(market.address, 1000, {from: deployer})
 
 			await market.vote(1000, {from: deployer})
@@ -88,21 +92,19 @@ contract('MarketTest', ([deployer, u1]) => {
 		})
 
 		it('Should fail to vote when already determined enabled', async () => {
-			market = await marketContract.new(addressConfig.address, u1, true, {
-				from: deployer
-			})
-			await dummyDEV.approve(market.address, 100, {from: deployer})
+			await dummyDEV.approve(market.address, 1000, {from: deployer})
 
-			const result = await market
-				.vote(100, {from: deployer})
+			await market.vote(900, {from: deployer})
+			const isEnable = await market.enabled({from: deployer})
+
+			expect(isEnable).to.be.equal(true)
+
+			const result = await market.vote(100, {from: deployer})
 				.catch((err: Error) => err)
-			expect(result).to.instanceOf(Error)
+			expect((result as Error).message).to.be.equal("Returned error: VM Exception while processing transaction: revert market is already enabled -- Reason given: market is already enabled.")
 		})
 
 		it('Vote decrease the number of sent DEVs from voter owned DEVs', async () => {
-			market = await marketContract.new(addressConfig.address, u1, false, {
-				from: deployer
-			})
 			await dummyDEV.approve(market.address, 100, {from: deployer})
 
 			await market.vote(100, {from: deployer})
@@ -112,9 +114,6 @@ contract('MarketTest', ([deployer, u1]) => {
 		})
 
 		it('Vote decrease the number of sent DEVs from DEVtoken totalSupply', async () => {
-			market = await marketContract.new(addressConfig.address, u1, false, {
-				from: deployer
-			})
 			await dummyDEV.approve(market.address, 100, {from: deployer})
 
 			await market.vote(100, {from: deployer})

--- a/test/market/market.ts
+++ b/test/market/market.ts
@@ -99,9 +99,12 @@ contract('MarketTest', ([deployer, behavior]) => {
 
 			expect(isEnable).to.be.equal(true)
 
-			const result = await market.vote(100, {from: deployer})
+			const result = await market
+				.vote(100, {from: deployer})
 				.catch((err: Error) => err)
-			expect((result as Error).message).to.be.equal("Returned error: VM Exception while processing transaction: revert market is already enabled -- Reason given: market is already enabled.")
+			expect((result as Error).message).to.be.equal(
+				'Returned error: VM Exception while processing transaction: revert market is already enabled -- Reason given: market is already enabled.'
+			)
 		})
 
 		it('Vote decrease the number of sent DEVs from voter owned DEVs', async () => {

--- a/test/property/property-factory.ts
+++ b/test/property/property-factory.ts
@@ -54,7 +54,6 @@ contract('PropertyFactoryTest', ([deployer]) => {
 		})
 
 		it('Create a new Property Contract and emit Create Event telling created property address', async () => {
-			// eslint-disable-next-line @typescript-eslint/await-thenable
 			deployedProperty = await propertyContract.at(expectedPropertyAddress)
 			const name = await deployedProperty.name({from: deployer})
 			const symbol = await deployedProperty.symbol({from: deployer})


### PR DESCRIPTION
# Description

#67 

# Why

From whitepaper v2.x, decide to enable a Market by the marketApproval method in Policy.
Because so, the vote method is should calling the marketApproval method in Policy.

