### PR TITLE
Added an argument as an owner to the property factory

### DIFF
--- a/contracts/src/property/PropertyFactory.sol
+++ b/contracts/src/property/PropertyFactory.sol
@@ -13,10 +13,11 @@ contract PropertyFactory is Pausable, UsingConfig {
 	// solium-disable-next-line no-empty-blocks
 	constructor(address _config) public UsingConfig(_config) {}
 
-	function create(string calldata _name, string calldata _symbol)
-		external
-		returns (address)
-	{
+	function create(
+		string calldata _name,
+		string calldata _symbol,
+		address _author
+	) external returns (address) {
 		require(paused() == false, "You cannot use that");
 		StringValidator validator = new StringValidator();
 		validator.validatePropertyName(_name);
@@ -24,7 +25,7 @@ contract PropertyFactory is Pausable, UsingConfig {
 
 		Property property = new Property(
 			address(config()),
-			msg.sender,
+			_author,
 			_name,
 			_symbol
 		);

--- a/migrations/mock/property.ts
+++ b/migrations/mock/property.ts
@@ -13,9 +13,7 @@ export async function createProperty(
 		const eventLog = await propertyFactory.create(
 			`NAME${index}`,
 			`SYMBOL${index}`,
-			{
-				from: address
-			}
+			address
 		)
 		const propertyAddress = await eventLog.logs.filter(
 			(e: {event: string}) => e.event === 'Create'

--- a/test/dev/dev.ts
+++ b/test/dev/dev.ts
@@ -219,7 +219,7 @@ contract(
 				dev: DevProtocolInstance
 			): Promise<string> =>
 				dev.propertyFactory
-					.create('test', 'test')
+					.create('test', 'test', deployer)
 					.then(res => res.logs.find(x => x.event === 'Create')?.args._property)
 
 			it('lockup token to properties', async () => {

--- a/test/market/market.ts
+++ b/test/market/market.ts
@@ -169,7 +169,7 @@ contract('MarketTest', ([deployer]) => {
 			)[0].args._market
 			// eslint-disable-next-line @typescript-eslint/await-thenable
 			market = await marketContract.at(marketAddress)
-			result = await propertyFactory.create('sample', 'SAMPLE', {
+			result = await propertyFactory.create('sample', 'SAMPLE', deployer, {
 				from: deployer
 			})
 			propertyAddress = await result.logs.filter(

--- a/test/property/property-factory.ts
+++ b/test/property/property-factory.ts
@@ -1,14 +1,24 @@
-contract('PropertyFactoryTest', ([deployer]) => {
+import {
+	PropertyFactoryInstance,
+	PropertyGroupInstance
+} from '../../types/truffle-contracts'
+
+contract('PropertyFactoryTest', ([deployer, user]) => {
 	const propertyContract = artifacts.require('Property')
 	const propertyGroupContract = artifacts.require('PropertyGroup')
 	const addressConfigContract = artifacts.require('AddressConfig')
 	const propertyFactoryContract = artifacts.require('PropertyFactory')
 	const voteTimesContract = artifacts.require('VoteTimes')
 	const voteTimesStorageContract = artifacts.require('VoteTimesStorage')
+	const getPropertyAddress = async (
+		result: Truffle.TransactionResponse
+	): Promise<string> =>
+		result.logs.filter((e: {event: string}) => e.event === 'Create')[0].args
+			._property
 	describe('PropertyFactory; createProperty', () => {
-		let propertyFactory: any
-		let propertyGroup: any
-		let expectedPropertyAddress: any
+		let propertyFactory: PropertyFactoryInstance
+		let propertyGroup: PropertyGroupInstance
+		let expectedPropertyAddress: string
 		beforeEach(async () => {
 			const addressConfig = await addressConfigContract.new({from: deployer})
 			propertyGroup = await propertyGroupContract.new(addressConfig.address, {
@@ -45,10 +55,10 @@ contract('PropertyFactoryTest', ([deployer]) => {
 			})
 			// eslint-disable-next-line no-warning-comments
 			// TODO multi byte string
-			const result = await propertyFactory.create('sample', 'SAMPLE')
-			expectedPropertyAddress = await result.logs.filter(
-				(e: {event: string}) => e.event === 'Create'
-			)[0].args._property
+			const result = await propertyFactory.create('sample', 'SAMPLE', user, {
+				from: deployer
+			})
+			expectedPropertyAddress = await getPropertyAddress(result)
 		})
 
 		it('Create a new Property Contract and emit Create Event telling created property address', async () => {
@@ -60,10 +70,12 @@ contract('PropertyFactoryTest', ([deployer]) => {
 			const symbol = await deployedProperty.symbol({from: deployer})
 			const decimals = await deployedProperty.decimals({from: deployer})
 			const totalSupply = await deployedProperty.totalSupply({from: deployer})
+			const author = await deployedProperty.author({from: deployer})
 			expect(name).to.be.equal('sample')
 			expect(symbol).to.be.equal('SAMPLE')
 			expect(decimals.toNumber()).to.be.equal(18)
 			expect(totalSupply.toNumber()).to.be.equal(10000000)
+			expect(author).to.be.equal(user)
 		})
 
 		it('Adds a new Property Contract address to State Contract', async () => {

--- a/test/property/property.ts
+++ b/test/property/property.ts
@@ -56,7 +56,7 @@ contract('PropertyTest', ([deployer, ui]) => {
 			await addressConfig.setPropertyFactory(propertyFactory.address, {
 				from: deployer
 			})
-			const result = await propertyFactory.create('sample', 'SAMPLE', {
+			const result = await propertyFactory.create('sample', 'SAMPLE', ui, {
 				from: ui
 			})
 			propertyAddress = await result.logs.filter(


### PR DESCRIPTION
# Description

I added an argument as an owner address specification to Property Factory's create method.

# Why

To create a new Property Contract, an application layer should be able to delegate from the sender.

Even if it creates a new Property Contract using someone else's address is no problem because only the owner can authenticate a new asset.

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
