### PR TITLE
To no run solium in flattened dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"predeploy": "npm run build",
 		"lint": "npm run lint:eslint && npm run lint:solium && npm run lint:format",
 		"lint:eslint": "eslint . --ext .ts,.js --fix",
-		"lint:solium": "solium --dir . --fix",
+		"lint:solium": "solium --dir contracts --fix",
 		"lint:format": "prettier --write '**/*.{sol,js,json,md,yml}'",
 		"prepack": "npm run build",
 		"build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
# Description

I changed the lint script to no run solium in flattened dir.

# Why

Flattened files are build deliverables, solium is no longer needed.

# Related Issues

Fixes # .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
