### PR TITLE
Runs CI only on the node 10.x.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
# Description

I changed the configuration for GitHub Actions to runs CI only on the node 10.x.

# Why

Web3 is often unstable on node 12x. Since the test is only on the Ethereum network, only the stable 10x version is sufficient.

# Related Issues

Fixes # .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
