### PR TITLE
delete library link

### DIFF
--- a/contracts/src/common/libs/Decimals.sol
+++ b/contracts/src/common/libs/Decimals.sol
@@ -21,7 +21,11 @@ library Decimals {
 		return (a.div(_b));
 	}
 
-	function basis() external pure returns (uint120) {
-		return basisValue;
+	function mulBasis(uint256 _a) internal pure returns (uint256) {
+		return _a.mul(basisValue);
+	}
+
+	function divBasis(uint256 _a) internal pure returns (uint256) {
+		return _a.div(basisValue);
 	}
 }

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -254,7 +254,7 @@ contract Lockup is ILockup, Pausable, UsingConfig, UsingValidator {
 		(uint256 valuePerProperty, , ) = getCumulativeLockedUp(_property);
 		(uint256 valueAll, , ) = getCumulativeLockedUpAll();
 		uint256 propertyRewards = rewards.sub(_lastReward).mul(
-			valuePerProperty.mul(Decimals.basis()).outOf(valueAll)
+			valuePerProperty.mulBasis().outOf(valueAll)
 		);
 		uint256 lockedUpPerProperty = lockupStorage.getPropertyValue(_property);
 		uint256 totalSupply = ERC20Mintable(_property).totalSupply();
@@ -286,7 +286,7 @@ contract Lockup is ILockup, Pausable, UsingConfig, UsingValidator {
 		(uint256 nextRewards, ) = dry(lockupStorage);
 		(uint256 valuePerProperty, , ) = getCumulativeLockedUp(_property);
 		(uint256 valueAll, , ) = getCumulativeLockedUpAll();
-		uint256 share = valuePerProperty.mul(Decimals.basis()).outOf(valueAll);
+		uint256 share = valuePerProperty.mulBasis().outOf(valueAll);
 		uint256 propertyRewards = nextRewards.mul(share);
 		uint256 lockedUp = lockupStorage.getPropertyValue(_property);
 		uint256 holders = Policy(config().policy()).holdersShare(
@@ -314,7 +314,7 @@ contract Lockup is ILockup, Pausable, UsingConfig, UsingValidator {
 		uint256 lockedUpPerAccount = lockupStorage.getValue(_property, _user);
 		uint256 amount = price.mul(lockedUpPerAccount);
 		uint256 result = amount > 0
-			? amount.div(Decimals.basis()).div(Decimals.basis())
+			? amount.divBasis().divBasis()
 			: 0;
 		return (result, nextReward);
 	}
@@ -525,7 +525,7 @@ contract Lockup is ILockup, Pausable, UsingConfig, UsingValidator {
 		uint256 priceGap = price.sub(_last);
 		uint256 lockedUpValue = lockupStorage.getValue(_property, _user);
 		uint256 value = priceGap.mul(lockedUpValue);
-		return value.div(Decimals.basis());
+		return value.divBasis();
 	}
 
 	function __updateLegacyWithdrawableInterestAmount(

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -313,9 +313,7 @@ contract Lockup is ILockup, Pausable, UsingConfig, UsingValidator {
 		(uint256 nextReward, , , , uint256 price) = difference(_property, last);
 		uint256 lockedUpPerAccount = lockupStorage.getValue(_property, _user);
 		uint256 amount = price.mul(lockedUpPerAccount);
-		uint256 result = amount > 0
-			? amount.divBasis().divBasis()
-			: 0;
+		uint256 result = amount > 0 ? amount.divBasis().divBasis() : 0;
 		return (result, nextReward);
 	}
 

--- a/contracts/src/withdraw/Withdraw.sol
+++ b/contracts/src/withdraw/Withdraw.sol
@@ -153,7 +153,7 @@ contract Withdraw is IWithdraw, Pausable, UsingConfig, UsingValidator {
 			balance = balanceLimit;
 		}
 		uint256 value = _holdersPrice.mul(balance);
-		return (value.div(Decimals.basis()).div(Decimals.basis()), reward);
+		return (value.divBasis().divBasis(), reward);
 	}
 
 	function _calculateWithdrawableAmount(address _property, address _user)
@@ -187,7 +187,7 @@ contract Withdraw is IWithdraw, Pausable, UsingConfig, UsingValidator {
 			_property,
 			0
 		);
-		return _amount.div(Decimals.basis()).div(Decimals.basis());
+		return _amount.divBasis().divBasis();
 	}
 
 	function __legacyWithdrawableAmount(address _property, address _user)
@@ -204,7 +204,7 @@ contract Withdraw is IWithdraw, Pausable, UsingConfig, UsingValidator {
 		uint256 priceGap = price.sub(_last);
 		uint256 balance = ERC20Mintable(_property).balanceOf(_user);
 		uint256 value = priceGap.mul(balance);
-		return value.div(Decimals.basis());
+		return value.divBasis();
 	}
 
 	function __updateLegacyWithdrawableAmount(address _property, address _user)

--- a/contracts/test/common/libs/Decimals.sol
+++ b/contracts/test/common/libs/Decimals.sol
@@ -12,4 +12,20 @@ contract DecimalsTest {
 	{
 		return _a.outOf(_b);
 	}
+
+	function mulBasis(uint256 _a)
+		external
+		pure
+		returns (uint256 result)
+	{
+		return _a.mulBasis();
+	}
+
+	function divBasis(uint256 _a)
+		external
+		pure
+		returns (uint256 result)
+	{
+		return _a.divBasis();
+	}
 }

--- a/contracts/test/common/libs/Decimals.sol
+++ b/contracts/test/common/libs/Decimals.sol
@@ -13,19 +13,11 @@ contract DecimalsTest {
 		return _a.outOf(_b);
 	}
 
-	function mulBasis(uint256 _a)
-		external
-		pure
-		returns (uint256 result)
-	{
+	function mulBasis(uint256 _a) external pure returns (uint256 result) {
 		return _a.mulBasis();
 	}
 
-	function divBasis(uint256 _a)
-		external
-		pure
-		returns (uint256 result)
-	{
+	function divBasis(uint256 _a) external pure returns (uint256 result) {
 		return _a.divBasis();
 	}
 }

--- a/contracts/test/policy/PolicyTest1.sol
+++ b/contracts/test/policy/PolicyTest1.sol
@@ -21,7 +21,7 @@ contract PolicyTest1 is IPolicy {
 	{
 		uint256 sum = _amount + _lockups;
 		uint256 share = _lockups.outOf(sum);
-		return _amount - ((_amount * share) / Decimals.basis());
+		return _amount - (_amount * share).divBasis();
 	}
 
 	function assetValue(uint256 _value, uint256 _lockups)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprtcl/protocol",
-	"version": "0.1.5",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/test/common/libs/decimals.ts
+++ b/test/common/libs/decimals.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js'
-
+import {toBigNumber} from '../../test-lib/utils/common'
+import {validateErrorMessage} from '../../test-lib/utils/error'
 contract('DecimalsTest', ([deployer]) => {
 	const decimalsTestContract = artifacts.require('DecimalsTest')
 	describe('Decimals; outOf', () => {
@@ -21,6 +22,49 @@ contract('DecimalsTest', ([deployer]) => {
 				'700000000000000000000000000000000000000'
 			)
 			expect(result.toNumber()).to.be.equal(0)
+		})
+	})
+	describe('Decimals; mulBasis', () => {
+		it('The value multiplied by basis is returned.', async () => {
+			const decimalsTest = await decimalsTestContract.new({
+				from: deployer,
+			})
+			const resultBN = await decimalsTest.mulBasis(28).then(toBigNumber)
+			expect(resultBN.toString()).to.be.equal('28000000000000000000')
+		})
+		it('Whatever you multiply 0 by 0, you get 0.', async () => {
+			const decimalsTest = await decimalsTestContract.new({
+				from: deployer,
+			})
+			const resultBN = await decimalsTest.mulBasis(0).then(toBigNumber)
+			expect(resultBN.toString()).to.be.equal('0')
+		})
+		it('Large numbers cause overflow.', async () => {
+			const decimalsTest = await decimalsTestContract.new({
+				from: deployer,
+			})
+			const res = await decimalsTest
+				.mulBasis(toBigNumber(2 ** 255))
+				.catch((err: Error) => err)
+			validateErrorMessage(res, 'SafeMath: multiplication overflow', false)
+		})
+	})
+	describe('Decimals; divBasis', () => {
+		it('The value divided by basis comes back.', async () => {
+			const decimalsTest = await decimalsTestContract.new({
+				from: deployer,
+			})
+			const resultBN = await decimalsTest
+				.divBasis(toBigNumber(28000000000000000000))
+				.then(toBigNumber)
+			expect(resultBN.toString()).to.be.equal('28')
+		})
+		it('Zero is zero divided by whatever.', async () => {
+			const decimalsTest = await decimalsTestContract.new({
+				from: deployer,
+			})
+			const resultBN = await decimalsTest.divBasis(0).then(toBigNumber)
+			expect(resultBN.toString()).to.be.equal('0')
 		})
 	})
 })

--- a/test/test-lib/instance.ts
+++ b/test/test-lib/instance.ts
@@ -11,7 +11,6 @@ import {
 	LockupInstance,
 	LockupStorageInstance,
 	PropertyFactoryInstance,
-	DecimalsInstance,
 	PolicyFactoryInstance,
 	PolicySetInstance,
 	PolicyGroupInstance,
@@ -158,13 +157,10 @@ export class DevProtocolInstance {
 	}
 
 	public async generateAllocator(): Promise<void> {
-		this._allocator = await (async (x) => {
-			;(x as any).link(
-				'Decimals',
-				await this.generateDecimals().then((x) => x.address)
-			)
-			return x.new(this.addressConfig.address, this.fromDeployer)
-		})(contract('Allocator'))
+		this._allocator = await contract('Allocator').new(
+			this.addressConfig.address,
+			this.fromDeployer
+		)
 		await this._addressConfig.setAllocator(
 			this._allocator.address,
 			this.fromDeployer
@@ -183,13 +179,10 @@ export class DevProtocolInstance {
 	}
 
 	public async generateLockup(): Promise<void> {
-		this._lockup = await (async (x) => {
-			;(x as any).link(
-				'Decimals',
-				await this.generateDecimals().then((x) => x.address)
-			)
-			return x.new(this.addressConfig.address, this.fromDeployer)
-		})(contract('Lockup'))
+		this._lockup = await contract('Lockup').new(
+			this.addressConfig.address,
+			this.fromDeployer
+		)
 		await this._addressConfig.setLockup(this._lockup.address, this.fromDeployer)
 	}
 
@@ -356,13 +349,10 @@ export class DevProtocolInstance {
 	}
 
 	public async generateWithdraw(): Promise<void> {
-		this._withdraw = await (async (x) => {
-			;(x as any).link(
-				'Decimals',
-				await this.generateDecimals().then((x) => x.address)
-			)
-			return x.new(this.addressConfig.address, this.fromDeployer)
-		})(contract('Withdraw'))
+		this._withdraw = await contract('Withdraw').new(
+			this.addressConfig.address,
+			this.fromDeployer
+		)
 		await this._addressConfig.setWithdraw(
 			this._withdraw.address,
 			this.fromDeployer
@@ -381,22 +371,11 @@ export class DevProtocolInstance {
 		await this._withdrawStorage.createStorage(this.fromDeployer)
 	}
 
-	public async generateDecimals(): Promise<DecimalsInstance> {
-		return artifacts.require('Decimals').new(this.fromDeployer)
-	}
-
 	public async getPolicy(
 		contractName: string,
 		user: string
 	): Promise<IPolicyInstance> {
-		const tmp = await (async (x) => {
-			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-			;(x as any).link(
-				'Decimals',
-				await this.generateDecimals().then((x) => x.address)
-			)
-			return x.new({from: user})
-		})(contract(contractName))
+		const tmp = await contract(contractName).new({from: user})
 		return tmp
 	}
 


### PR DESCRIPTION
# Description

When you add a method to the Decimals library to perform a calculation using a basis, you can use the Eliminated the need to create a Link.

# Why

When deploying a contract that uses the Decimals library (e.g. Lockup), the We had to deploy the Decimals library every time, and the fee was a waste of money.