### PR TITLE
Implement `PropertyFactory.createAndAuthenticate`

### DIFF
--- a/contracts/src/market/IMarket.sol
+++ b/contracts/src/market/IMarket.sol
@@ -15,6 +15,21 @@ interface IMarket {
 			bool
 		);
 
+	function authenticateFromPropertyFactory(
+		address _prop,
+		address _author,
+		string calldata _args1,
+		string calldata _args2,
+		string calldata _args3,
+		string calldata _args4,
+		string calldata _args5
+	)
+		external
+		returns (
+			// solium-disable-next-line indentation
+			bool
+		);
+
 	function authenticatedCallback(address _property, bytes32 _idHash)
 		external
 		returns (address);

--- a/contracts/src/market/Market.sol
+++ b/contracts/src/market/Market.sol
@@ -102,7 +102,6 @@ contract Market is UsingConfig, IMarket, UsingValidator {
 	}
 
 	/**
-	 * Bypass to IMarketBehavior.authenticate.
 	 * Authenticates the new asset and proves that the Property author is the owner of the asset.
 	 */
 	function authenticate(
@@ -113,8 +112,69 @@ contract Market is UsingConfig, IMarket, UsingValidator {
 		string memory _args4,
 		string memory _args5
 	) public onlyPropertyAuthor(_prop) returns (bool) {
-		uint256 len = bytes(_args1).length;
-		require(len > 0, "id is required");
+		return
+			_authenticate(
+				_prop,
+				msg.sender,
+				_args1,
+				_args2,
+				_args3,
+				_args4,
+				_args5
+			);
+	}
+
+	/**
+	 * Authenticates the new asset and proves that the Property author is the owner of the asset.
+	 */
+	function authenticateFromPropertyFactory(
+		address _prop,
+		address _author,
+		string calldata _args1,
+		string calldata _args2,
+		string calldata _args3,
+		string calldata _args4,
+		string calldata _args5
+	) external returns (bool) {
+		/**
+		 * Validates the sender is PropertyFactory.
+		 */
+		addressValidator().validateAddress(
+			msg.sender,
+			config().propertyFactory()
+		);
+
+		/**
+		 * Validates this Market is already enabled..
+		 */
+		require(enabled, "market is not enabled");
+
+		return
+			_authenticate(
+				_prop,
+				_author,
+				_args1,
+				_args2,
+				_args3,
+				_args4,
+				_args5
+			);
+	}
+
+	/**
+	 * Bypass to IMarketBehavior.authenticate.
+	 * Authenticates the new asset and proves that the Property author is the owner of the asset.
+	 */
+	function _authenticate(
+		address _prop,
+		address _author,
+		string memory _args1,
+		string memory _args2,
+		string memory _args3,
+		string memory _args4,
+		string memory _args5
+	) private returns (bool) {
+		require(bytes(_args1).length > 0, "id is required");
 
 		return
 			IMarketBehavior(behavior).authenticate(
@@ -125,7 +185,7 @@ contract Market is UsingConfig, IMarket, UsingValidator {
 				_args4,
 				_args5,
 				address(this),
-				msg.sender
+				_author
 			);
 	}
 

--- a/contracts/src/property/IPropertyFactory.sol
+++ b/contracts/src/property/IPropertyFactory.sol
@@ -11,4 +11,18 @@ contract IPropertyFactory {
 			// solium-disable-next-line indentation
 			address
 		);
+
+	function createAndAuthenticate(
+		string calldata _name,
+		string calldata _symbol,
+		address _market,
+		string calldata _args1,
+		string calldata _args2,
+		string calldata _args3
+	)
+		external
+		returns (
+			// solium-disable-next-line indentation
+			bool
+		);
 }

--- a/contracts/src/property/PropertyFactory.sol
+++ b/contracts/src/property/PropertyFactory.sol
@@ -4,6 +4,7 @@ import {UsingConfig} from "contracts/src/common/config/UsingConfig.sol";
 import {Property} from "contracts/src/property/Property.sol";
 import {IGroup} from "contracts/src/property/PropertyGroup.sol";
 import {IPropertyFactory} from "contracts/src/property/IPropertyFactory.sol";
+import {IMarket} from "contracts/src/market/IMarket.sol";
 
 /**
  * A factory contract that creates a new Property contract.
@@ -25,12 +26,40 @@ contract PropertyFactory is UsingConfig, IPropertyFactory {
 		string calldata _symbol,
 		address _author
 	) external returns (address) {
-		/**
-		 * Validates the name and the token symbol.
-		 */
-		validatePropertyName(_name);
-		validatePropertySymbol(_symbol);
+		return _create(_name, _symbol, _author);
+	}
 
+	/**
+	 * Creates a new Property contract and authenticate.
+	 */
+	function createAndAuthenticate(
+		string calldata _name,
+		string calldata _symbol,
+		address _market,
+		string calldata _args1,
+		string calldata _args2,
+		string calldata _args3
+	) external returns (bool) {
+		return
+			IMarket(_market).authenticateFromPropertyFactory(
+				_create(_name, _symbol, msg.sender),
+				msg.sender,
+				_args1,
+				_args2,
+				_args3,
+				"",
+				""
+			);
+	}
+
+	/**
+	 * Creates a new Property contract.
+	 */
+	function _create(
+		string memory _name,
+		string memory _symbol,
+		address _author
+	) private returns (address) {
 		/**
 		 * Creates a new Property contract.
 		 */

--- a/contracts/src/property/PropertyFactory.sol
+++ b/contracts/src/property/PropertyFactory.sol
@@ -31,6 +31,7 @@ contract PropertyFactory is UsingConfig, IPropertyFactory {
 
 	/**
 	 * Creates a new Property contract and authenticate.
+	 * There are too many local variables, so when using this method limit the number of arguments that can be used to authenticate to a maximum of 3.
 	 */
 	function createAndAuthenticate(
 		string calldata _name,

--- a/contracts/src/property/PropertyFactory.sol
+++ b/contracts/src/property/PropertyFactory.sol
@@ -78,34 +78,4 @@ contract PropertyFactory is UsingConfig, IPropertyFactory {
 		emit Create(msg.sender, address(property));
 		return address(property);
 	}
-
-	/**
-	 * Validates the token name.
-	 */
-	function validatePropertyName(string memory _name) private pure {
-		uint256 len = bytes(_name).length;
-		require(
-			len >= 3,
-			"name must be at least 3 and no more than 10 characters"
-		);
-		require(
-			len <= 10,
-			"name must be at least 3 and no more than 10 characters"
-		);
-	}
-
-	/**
-	 * Validates the token symbol.
-	 */
-	function validatePropertySymbol(string memory _symbol) private pure {
-		uint256 len = bytes(_symbol).length;
-		require(
-			len >= 3,
-			"symbol must be at least 3 and no more than 10 characters"
-		);
-		require(
-			len <= 10,
-			"symbol must be at least 3 and no more than 10 characters"
-		);
-	}
 }

--- a/scripts/557-create-and-authenticate-one-tx.ts
+++ b/scripts/557-create-and-authenticate-one-tx.ts
@@ -1,0 +1,51 @@
+/* eslint-disable no-undef */
+import {createFastestGasPriceFetcher} from './lib/ethgas'
+import {ethgas} from './lib/api'
+
+const {CONFIG, EGS_TOKEN} = process.env
+const {log: ____log} = console
+const gas = 6721975
+
+const handler = async (
+	callback: (err: Error | null) => void
+): Promise<void> => {
+	if (!CONFIG || !EGS_TOKEN) {
+		return
+	}
+
+	const fastest = createFastestGasPriceFetcher(ethgas(EGS_TOKEN), web3)
+
+	// Generate current contract
+	const [config] = await Promise.all([
+		artifacts.require('AddressConfig').at(CONFIG),
+	])
+	____log('Generated AddressConfig contract', config.address)
+
+	// Deploy
+	const nextMarketFactory = await artifacts
+		.require('MarketFactory')
+		.new(config.address, {gasPrice: await fastest(), gas})
+	____log('Deployed the new MarketFactory', nextMarketFactory.address)
+
+	const nextPropertyFactory = await artifacts
+		.require('PropertyFactory')
+		.new(config.address, {gasPrice: await fastest(), gas})
+	____log('Deployed the new PropertyFactory', nextPropertyFactory.address)
+
+	// Enable new Contract
+	await config.setMarketFactory(nextMarketFactory.address, {
+		gasPrice: await fastest(),
+		gas,
+	})
+	____log('Updated MarketFactory address')
+
+	await config.setPropertyFactory(nextPropertyFactory.address, {
+		gasPrice: await fastest(),
+		gas,
+	})
+	____log('Updated PropertyFactory address')
+
+	callback(null)
+}
+
+export = handler

--- a/test/market/market.ts
+++ b/test/market/market.ts
@@ -158,7 +158,7 @@ contract(
 				const key = await behavuorInstance.getId(metrics.address)
 				expect(key).to.be.equal('id-key')
 			})
-			it('The address of the account that executed the authinticate function has been passed to the behavior.', async () => {
+			it(`The sender's address is passed to Market Behavior.`, async () => {
 				// eslint-disable-next-line @typescript-eslint/await-thenable
 				const marketInstance = await marketContract.at(marketAddress1)
 				await marketInstance.authenticate(
@@ -179,7 +179,7 @@ contract(
 					await marketTest3Instance.currentAuthinticateAccount()
 				).to.be.equal(propertyAuther)
 			})
-			it('Market that is not enabled generates an error when performing authentication function.', async () => {
+			it('Should fail to run when not enabled Market.', async () => {
 				// eslint-disable-next-line @typescript-eslint/await-thenable
 				const marketInstance = await marketContract.at(marketAddress2)
 				const result = await marketInstance
@@ -189,7 +189,7 @@ contract(
 					.catch((err: Error) => err)
 				validateErrorMessage(result, 'market is not enabled')
 			})
-			it('Error occurs if id is not set.', async () => {
+			it('Should fail to run when not passed the ID.', async () => {
 				// eslint-disable-next-line @typescript-eslint/await-thenable
 				const marketInstance = await marketContract.at(marketAddress1)
 				const result = await marketInstance
@@ -199,7 +199,7 @@ contract(
 					.catch((err: Error) => err)
 				validateErrorMessage(result, 'id is required')
 			})
-			it('Should fail to run when sent from other than the owner of Property Contract.', async () => {
+			it('Should fail to run when sent from other than Property Factory Contract.', async () => {
 				// eslint-disable-next-line @typescript-eslint/await-thenable
 				const marketInstance = await marketContract.at(marketAddress1)
 				const result = await marketInstance
@@ -207,7 +207,7 @@ contract(
 					.catch((err: Error) => err)
 				validateAddressErrorMessage(result)
 			})
-			it('An error occurs if the same id is specified.', async () => {
+			it('Should fail to run when the passed ID is already authenticated.', async () => {
 				// eslint-disable-next-line @typescript-eslint/await-thenable
 				const marketInstance = await marketContract.at(marketAddress1)
 				await marketInstance.authenticate(

--- a/test/property/property-factory.ts
+++ b/test/property/property-factory.ts
@@ -81,7 +81,7 @@ contract('PropertyFactoryTest', ([deployer, user, user2, marketFactory]) => {
 		})
 
 		it('Create a new Property and authenticate at the same time', async () => {
-			dev.propertyFactory
+			;(dev.propertyFactory as any)
 				.createAndAuthenticate(
 					'example',
 					'EXAMPLE',

--- a/test/property/property-factory.ts
+++ b/test/property/property-factory.ts
@@ -1,6 +1,5 @@
 import {DevProtocolInstance} from '../test-lib/instance'
 import {getPropertyAddress} from '../test-lib/utils/log'
-import {validateErrorMessage} from '../test-lib/utils/error'
 import {toBigNumber} from '../test-lib/utils/common'
 
 contract('PropertyFactoryTest', ([deployer, user, user2, marketFactory]) => {
@@ -45,96 +44,6 @@ contract('PropertyFactoryTest', ([deployer, user, user2, marketFactory]) => {
 			expect(author).to.be.equal(user)
 		})
 
-		it('2 characters name cause an error.', async () => {
-			const result = await dev.propertyFactory
-				.create('te', 'TEST', user, {
-					from: user2,
-				})
-				.catch((err: Error) => err)
-			validateErrorMessage(
-				result,
-				'name must be at least 3 and no more than 10 characters'
-			)
-		})
-		it('3 characters name donot cause an error.', async () => {
-			const result = await dev.propertyFactory.create('tes', 'TEST', user, {
-				from: user2,
-			})
-			const propertyAddress = getPropertyAddress(result)
-			// eslint-disable-next-line no-undef
-			const isAddress = web3.utils.isAddress(propertyAddress)
-			expect(isAddress).to.be.equal(true)
-		})
-		it('10 characters name cause an error.', async () => {
-			const result = await dev.propertyFactory.create(
-				'0123456789',
-				'TEST',
-				user,
-				{
-					from: user2,
-				}
-			)
-			const propertyAddress = getPropertyAddress(result)
-			// eslint-disable-next-line no-undef
-			const isAddress = web3.utils.isAddress(propertyAddress)
-			expect(isAddress).to.be.equal(true)
-		})
-		it('11 characters name cause an error.', async () => {
-			const result = await dev.propertyFactory
-				.create('01234567890', 'TEST', user, {
-					from: user2,
-				})
-				.catch((err: Error) => err)
-			validateErrorMessage(
-				result,
-				'name must be at least 3 and no more than 10 characters'
-			)
-		})
-		it('2 characters symbol cause an error.', async () => {
-			const result = await dev.propertyFactory
-				.create('test', 'TE', user, {
-					from: user2,
-				})
-				.catch((err: Error) => err)
-			validateErrorMessage(
-				result,
-				'symbol must be at least 3 and no more than 10 characters'
-			)
-		})
-		it('3 characters symbol donot cause an error.', async () => {
-			const result = await dev.propertyFactory.create('test', 'TES', user, {
-				from: user2,
-			})
-			const propertyAddress = getPropertyAddress(result)
-			// eslint-disable-next-line no-undef
-			const isAddress = web3.utils.isAddress(propertyAddress)
-			expect(isAddress).to.be.equal(true)
-		})
-		it('10 characters symbol cause an error.', async () => {
-			const result = await dev.propertyFactory.create(
-				'test',
-				'0123456789',
-				user,
-				{
-					from: user2,
-				}
-			)
-			const propertyAddress = getPropertyAddress(result)
-			// eslint-disable-next-line no-undef
-			const isAddress = web3.utils.isAddress(propertyAddress)
-			expect(isAddress).to.be.equal(true)
-		})
-		it('11 characters symbol cause an error.', async () => {
-			const result = await dev.propertyFactory
-				.create('test', '01234567890', user, {
-					from: user2,
-				})
-				.catch((err: Error) => err)
-			validateErrorMessage(
-				result,
-				'symbol must be at least 3 and no more than 10 characters'
-			)
-		})
 		it('Adds a new property contract address to state contract', async () => {
 			const isProperty = await dev.propertyGroup.isGroup(propertyAddress)
 			expect(isProperty).to.be.equal(true)


### PR DESCRIPTION
# Description

I implemented `PropertyFactory.createAndAuthenticate` method.

There are three updated contracts:
- contracts/src/market/IMarket.sol
- contracts/src/market/Market.sol
- contracts/src/property/IPropertyFactory.sol
- contracts/src/property/PropertyFactory.sol

The target of deployment is the following two:
- contracts/src/market/MarketFactory.sol
- contracts/src/property/PropertyFactory.sol

*VoteCounter also depends on IMarket, but is unaffected by the interface changes.

# Why

Required to complete Property creation and asset authentication in one transaction.

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
