### PR TITLE
delete unnecessary validate

### DIFF
--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -82,7 +82,10 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		/**
 		 * Refuses new staking when after cancel staking and until release it.
 		 */
-		require(getStorageWithdrawalStatus(_property, _from) == 0, "lockup is already canceled");
+		require(
+			getStorageWithdrawalStatus(_property, _from) == 0,
+			"lockup is already canceled"
+		);
 
 		/**
 		 * Since the reward per block that can be withdrawn will change with the addition of staking,

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -64,7 +64,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		/**
 		 * Validates the sender is Dev contract.
 		 */
-		require(msg.sender == config().token(), "illegal sender address");
+		addressValidator().validateAddress(msg.sender, config().token());
 
 		/**
 		 * Validates _value is not 0.

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -82,10 +82,8 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		/**
 		 * Refuses new staking when after cancel staking and until release it.
 		 */
-		require(
-			getStorageWithdrawalStatus(_property, _from) == 0,
-			"lockup is already canceled"
-		);
+		bool isWaiting = getStorageWithdrawalStatus(_property, _from) != 0;
+		require(isWaiting == false, "lockup is already canceled");
 
 		/**
 		 * Since the reward per block that can be withdrawn will change with the addition of staking,

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -69,7 +69,6 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		/**
 		 * Validates the target of staking is included Property set.
 		 */
-		addressValidator().validateGroup(_property, config().propertyGroup());
 		require(_value != 0, "illegal lockup value");
 
 		/**

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -82,8 +82,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		/**
 		 * Refuses new staking when after cancel staking and until release it.
 		 */
-		bool isWaiting = getStorageWithdrawalStatus(_property, _from) != 0;
-		require(isWaiting == false, "lockup is already canceled");
+		require(getStorageWithdrawalStatus(_property, _from) == 0, "lockup is already canceled");
 
 		/**
 		 * Since the reward per block that can be withdrawn will change with the addition of staking,

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -67,7 +67,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		addressValidator().validateAddress(msg.sender, config().token());
 
 		/**
-		 * Validates the target of staking is included Property set.
+		 * Validates _value is not 0.
 		 */
 		require(_value != 0, "illegal lockup value");
 

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -64,7 +64,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		/**
 		 * Validates the sender is Dev contract.
 		 */
-		addressValidator().validateAddress(msg.sender, config().token());
+		require(msg.sender == config().token(), "illegal sender address");
 
 		/**
 		 * Validates _value is not 0.

--- a/scripts/592-cut-gas-price.ts
+++ b/scripts/592-cut-gas-price.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-undef */
+import {config} from 'dotenv'
+import {createFastestGasPriceFetcher} from './lib/ethgas'
+import {ethgas} from './lib/api'
+import {DevCommonInstance} from './lib/instance/common'
+import {Lockup} from './lib/instance/lockup'
+
+config()
+const {CONFIG: configAddress, EGS_TOKEN: egsApiKey} = process.env
+
+const handler = async (
+	callback: (err: Error | null) => void
+): Promise<void> => {
+	if (!configAddress || !egsApiKey) {
+		return
+	}
+
+	const gasFetcher = async () => 6721975
+	const gasPriceFetcher = createFastestGasPriceFetcher(ethgas(egsApiKey), web3)
+	const dev = new DevCommonInstance(
+		artifacts,
+		configAddress,
+		gasFetcher,
+		gasPriceFetcher
+	)
+	await dev.prepare()
+
+	// Lockup
+	const lockup = new Lockup(dev)
+	const lockupInstance = await lockup.load()
+	const nextLockupInstance = await lockup.create()
+	await lockup.changeOwner(lockupInstance, nextLockupInstance)
+	await lockup.set(nextLockupInstance)
+
+	callback(null)
+}
+
+export = handler

--- a/test/dev/dev.ts
+++ b/test/dev/dev.ts
@@ -277,7 +277,7 @@ contract('Dev', ([deployer, user1, user2, marketFactory, market]) => {
 			const transaction = await dev.dev.deposit(prop, 50, {from: user1})
 			const gasPrice = Number(transaction.receipt.gasUsed)
 			console.log(gasPrice)
-			expect(gasPrice <= 849408).to.be.equal(true)
+			expect(gasPrice <= 849424).to.be.equal(true)
 		})
 		it('should fail to lock up token when 0 amount', async () => {
 			const dev = await generateEnv()

--- a/test/dev/dev.ts
+++ b/test/dev/dev.ts
@@ -269,6 +269,15 @@ contract('Dev', ([deployer, user1, user2, marketFactory, market]) => {
 				50
 			)
 		})
+		it.only('check gas used', async () => {
+			const dev = await generateEnv()
+			const prop = await createProperty(dev)
+			await dev.metricsGroup.__setMetricsCountPerProperty(prop, 1)
+			await dev.dev.mint(user1, 100)
+			const transaction = await dev.dev.deposit(prop, 50, {from: user1})
+			const gasPrice = Number(transaction.receipt.gasUsed)
+			expect(gasPrice <= 846579).to.be.equal(true)
+		})
 		it('should fail to lock up token when 0 amount', async () => {
 			const dev = await generateEnv()
 			const prop = await createProperty(dev)

--- a/test/dev/dev.ts
+++ b/test/dev/dev.ts
@@ -269,7 +269,7 @@ contract('Dev', ([deployer, user1, user2, marketFactory, market]) => {
 				50
 			)
 		})
-		it.only('check gas used', async () => {
+		it('check gas used', async () => {
 			const dev = await generateEnv()
 			const prop = await createProperty(dev)
 			await dev.metricsGroup.__setMetricsCountPerProperty(prop, 1)

--- a/test/dev/dev.ts
+++ b/test/dev/dev.ts
@@ -277,7 +277,7 @@ contract('Dev', ([deployer, user1, user2, marketFactory, market]) => {
 			const transaction = await dev.dev.deposit(prop, 50, {from: user1})
 			const gasPrice = Number(transaction.receipt.gasUsed)
 			console.log(gasPrice)
-			expect(gasPrice <= 846563).to.be.equal(true)
+			expect(gasPrice <= 849408).to.be.equal(true)
 		})
 		it('should fail to lock up token when 0 amount', async () => {
 			const dev = await generateEnv()

--- a/test/dev/dev.ts
+++ b/test/dev/dev.ts
@@ -276,7 +276,8 @@ contract('Dev', ([deployer, user1, user2, marketFactory, market]) => {
 			await dev.dev.mint(user1, 100)
 			const transaction = await dev.dev.deposit(prop, 50, {from: user1})
 			const gasPrice = Number(transaction.receipt.gasUsed)
-			expect(gasPrice <= 846579).to.be.equal(true)
+			console.log(gasPrice)
+			expect(gasPrice <= 846563).to.be.equal(true)
 		})
 		it('should fail to lock up token when 0 amount', async () => {
 			const dev = await generateEnv()

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -113,7 +113,7 @@ contract('LockupTest', ([deployer, user1]) => {
 			const res = await dev.lockup
 				.lockup(deployer, property.address, 10000)
 				.catch(err)
-			validateErrorMessage(res, 'illegal sender address')
+			validateErrorMessage(res, 'this is illegal address')
 		})
 		it('should fail to call when passed address is not property contract', async () => {
 			const [dev] = await init()

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -113,7 +113,7 @@ contract('LockupTest', ([deployer, user1]) => {
 			const res = await dev.lockup
 				.lockup(deployer, property.address, 10000)
 				.catch(err)
-			validateErrorMessage(res, 'this is illegal address')
+			validateErrorMessage(res, 'illegal sender address')
 		})
 		it.only('should fail to call when passed address is not property contract', async () => {
 			const [dev] = await init()

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -115,7 +115,7 @@ contract('LockupTest', ([deployer, user1]) => {
 				.catch(err)
 			validateErrorMessage(res, 'illegal sender address')
 		})
-		it.only('should fail to call when passed address is not property contract', async () => {
+		it('should fail to call when passed address is not property contract', async () => {
 			const [dev] = await init()
 
 			const res = await dev.dev.deposit(user1, 10000).catch(err)

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -115,11 +115,11 @@ contract('LockupTest', ([deployer, user1]) => {
 				.catch(err)
 			validateErrorMessage(res, 'this is illegal address')
 		})
-		it('should fail to call when passed address is not property contract', async () => {
+		it.only('should fail to call when passed address is not property contract', async () => {
 			const [dev] = await init()
 
-			const res = await dev.lockup.lockup(deployer, user1, 10000).catch(err)
-			validateErrorMessage(res, 'this is illegal address')
+			const res = await dev.dev.deposit(user1, 10000).catch(err)
+			validateErrorMessage(res, 'unable to stake to unauthenticated property')
 		})
 		it('should fail to call when lockup is canceling', async () => {
 			const [dev, property] = await init()


### PR DESCRIPTION
# Description

delete unnecessary validate

# Why

To lower gas bill.
To begin with, if the argument _property is not a Property address, this is where the error occurs

```
		/**
		 * Validates the passed Property has greater than 1 asset.
		 */
		require(
			IMetricsGroup(config().metricsGroup()).hasAssets(_property),
			"unable to stake to unauthenticated property"
		);

```

# Note

As an example, when you deposit a DEV, your gas bill goes down as shown below.

862564->849424
(About 2% down)


## testnet
- [x] Deploying Lockup
- [x] Register the Lockup  source code.
- [x] Change the setting of the event saver of the Lockup.

## mainnet
- [ ] Deploying Lockup
- [ ] Register the Lockup  source code.
- [ ] Change the setting of the event saver of the Lockup.

