### PR TITLE
Withdraw staking and rewards by one transaction, and supports partial withdrawal

### DIFF
--- a/contracts/src/lockup/ILockup.sol
+++ b/contracts/src/lockup/ILockup.sol
@@ -10,7 +10,7 @@ contract ILockup {
 
 	function update() public;
 
-	function withdraw(address _property) external;
+	function withdraw(address _property, uint256 _amount) external;
 
 	function calculateCumulativeRewardPrices()
 		public
@@ -48,6 +48,4 @@ contract ILockup {
 			// solium-disable-next-line indentation
 			uint256
 		);
-
-	function withdrawInterest(address _property) external;
 }

--- a/contracts/src/lockup/ILockup.sol
+++ b/contracts/src/lockup/ILockup.sol
@@ -10,8 +10,6 @@ contract ILockup {
 
 	function update() public;
 
-	function cancel(address _property) external;
-
 	function withdraw(address _property) external;
 
 	function calculateCumulativeRewardPrices()

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -678,14 +678,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		returns (bool)
 	{
 		uint256 blockNumber = getStorageWithdrawalStatus(_property, _from);
-		if (blockNumber <= block.number) {
-			return true;
-		} else {
-			if (IPolicy(config().policy()).lockUpBlocks() == 1) {
-				return true;
-			}
-		}
-		return false;
+		return blockNumber <= block.number;
 	}
 
 	/**

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -402,7 +402,8 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		 * Gets the latest withdrawal reward amount.
 		 */
 		(
-			uint256 amount,,
+			uint256 amount,
+			,
 			RewardPrices memory prices
 		) = _calculateInterestAmount(_property, _user);
 

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -119,7 +119,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		 */
 		require(
 			hasValue(_property, msg.sender, _amount),
-			"dev token is not locked"
+			"tokens are not staked or insufficient staked"
 		);
 
 		/**
@@ -605,7 +605,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		uint256 _amount
 	) private view returns (bool) {
 		uint256 value = getStorageValue(_property, _sender);
-		return value >= _amount;
+		return value > 0 && value >= _amount;
 	}
 
 	/**

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -378,22 +378,14 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 	function _calculateWithdrawableInterestAmount(
 		address _property,
 		address _user
-	)
-		private
-		view
-		returns (
-			uint256 _amount,
-			uint256 _interestPrice,
-			RewardPrices memory _prices
-		)
-	{
+	) private view returns (uint256 _amount, RewardPrices memory _prices) {
 		/**
 		 * If the passed Property has not authenticated, returns always 0.
 		 */
 		if (
 			IMetricsGroup(config().metricsGroup()).hasAssets(_property) == false
 		) {
-			return (0, 0, RewardPrices(0, 0, 0));
+			return (0, RewardPrices(0, 0, 0));
 		}
 
 		/**
@@ -421,7 +413,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		uint256 withdrawableAmount = amount
 			.add(pending) // solium-disable-next-line indentation
 			.add(legacy);
-		return (withdrawableAmount, interestPrice, prices);
+		return (withdrawableAmount, prices);
 	}
 
 	/**
@@ -431,7 +423,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		address _property,
 		address _user
 	) public view returns (uint256) {
-		(uint256 amount, , ) = _calculateWithdrawableInterestAmount(
+		(uint256 amount, ) = _calculateWithdrawableInterestAmount(
 			_property,
 			_user
 		);
@@ -450,7 +442,6 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		 */
 		(
 			uint256 value,
-			uint256 interestPrice,
 			RewardPrices memory prices
 		) = _calculateWithdrawableInterestAmount(_property, msg.sender);
 
@@ -467,7 +458,11 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		/**
 		 * Updates the staking status to avoid double rewards.
 		 */
-		setStorageLastStakedInterestPrice(_property, msg.sender, interestPrice);
+		setStorageLastStakedInterestPrice(
+			_property,
+			msg.sender,
+			prices.interest
+		);
 		__updateLegacyWithdrawableInterestAmount(_property, msg.sender);
 
 		/**
@@ -654,7 +649,6 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		 */
 		(
 			uint256 withdrawableAmount,
-			,
 			RewardPrices memory prices
 		) = _calculateWithdrawableInterestAmount(_property, _user);
 

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -119,7 +119,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		 */
 		require(
 			hasValue(_property, msg.sender, _amount),
-			"tokens are not staked or insufficient staked"
+			"insufficient tokens staked"
 		);
 
 		/**
@@ -605,7 +605,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		uint256 _amount
 	) private view returns (bool) {
 		uint256 value = getStorageValue(_property, _sender);
-		return value > 0 && value >= _amount;
+		return value >= _amount;
 	}
 
 	/**

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -89,8 +89,8 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		 */
 		setStorageWithdrawalStatus(
 			_property,
-			msg.sender,
-			block.number.add(IPolicy(config().policy()).lockUpBlocks())
+			_from,
+			IPolicy(config().policy()).lockUpBlocks().add(block.number)
 		);
 
 		/**
@@ -402,8 +402,7 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		 * Gets the latest withdrawal reward amount.
 		 */
 		(
-			uint256 amount,
-			uint256 interestPrice,
+			uint256 amount,,
 			RewardPrices memory prices
 		) = _calculateInterestAmount(_property, _user);
 

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -85,15 +85,6 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		);
 
 		/**
-		 * Updates minimum staking duration.
-		 */
-		setStorageWithdrawalStatus(
-			_property,
-			_from,
-			IPolicy(config().policy()).lockUpBlocks().add(block.number)
-		);
-
-		/**
 		 * Since the reward per block that can be withdrawn will change with the addition of staking,
 		 * saves the undrawn withdrawable reward before addition it.
 		 */
@@ -121,11 +112,6 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 			hasValue(_property, msg.sender, _amount),
 			"insufficient tokens staked"
 		);
-
-		/**
-		 * Validates the block number reaches the block number where staking can be released.
-		 */
-		require(possible(_property, msg.sender), "waiting for release");
 
 		/**
 		 * Withdraws the staking reward
@@ -667,18 +653,6 @@ contract Lockup is ILockup, UsingConfig, UsingValidator, LockupStorage {
 		__updateLegacyWithdrawableInterestAmount(_property, _user);
 
 		return prices;
-	}
-
-	/**
-	 * Returns whether the staking can be released.
-	 */
-	function possible(address _property, address _from)
-		private
-		view
-		returns (bool)
-	{
-		uint256 blockNumber = getStorageWithdrawalStatus(_property, _from);
-		return blockNumber <= block.number;
 	}
 
 	/**

--- a/contracts/src/lockup/LockupStorage.sol
+++ b/contracts/src/lockup/LockupStorage.sol
@@ -75,36 +75,6 @@ contract LockupStorage is UsingStorage {
 		return keccak256(abi.encodePacked("_propertyValue", _property));
 	}
 
-	//WithdrawalStatus
-	function setStorageWithdrawalStatus(
-		address _property,
-		address _from,
-		uint256 _value
-	) internal {
-		bytes32 key = getStorageWithdrawalStatusKey(_property, _from);
-		eternalStorage().setUint(key, _value);
-	}
-
-	function getStorageWithdrawalStatus(address _property, address _from)
-		public
-		view
-		returns (uint256)
-	{
-		bytes32 key = getStorageWithdrawalStatusKey(_property, _from);
-		return eternalStorage().getUint(key);
-	}
-
-	function getStorageWithdrawalStatusKey(address _property, address _sender)
-		private
-		pure
-		returns (bytes32)
-	{
-		return
-			keccak256(
-				abi.encodePacked("_withdrawalStatus", _property, _sender)
-			);
-	}
-
 	//InterestPrice
 	function setStorageInterestPrice(address _property, uint256 _value)
 		internal

--- a/contracts/src/policy/IPolicy.sol
+++ b/contracts/src/policy/IPolicy.sol
@@ -36,6 +36,4 @@ contract IPolicy {
 	function policyVotingBlocks() external view returns (uint256);
 
 	function abstentionPenalty(uint256 _count) external view returns (uint256);
-
-	function lockUpBlocks() external view returns (uint256);
 }

--- a/contracts/test/lockup/LockupStorageTest.sol
+++ b/contracts/test/lockup/LockupStorageTest.sol
@@ -15,14 +15,6 @@ contract LockupStorageTest is LockupStorage {
 		setStorageValue(_property, _sender, _value);
 	}
 
-	function setStorageWithdrawalStatusTest(
-		address _property,
-		address _from,
-		uint256 _value
-	) external {
-		setStorageWithdrawalStatus(_property, _from, _value);
-	}
-
 	function setStorageInterestPriceTest(address _property, uint256 _value)
 		external
 	{

--- a/contracts/test/policy/PolicyTestForLockup.sol
+++ b/contracts/test/policy/PolicyTestForLockup.sol
@@ -72,12 +72,4 @@ contract PolicyTestForLockup is IPolicy {
 	function abstentionPenalty(uint256 _count) external view returns (uint256) {
 		return _count > 1 ? 5 : 0;
 	}
-
-	function lockUpBlocks() external view returns (uint256) {
-		return _lockUpBlocks;
-	}
-
-	function setLockUpBlocks(uint256 _blocks) public {
-		_lockUpBlocks = _blocks;
-	}
 }

--- a/scripts/632-one-transaction-withdrawal.ts
+++ b/scripts/632-one-transaction-withdrawal.ts
@@ -1,0 +1,37 @@
+/* eslint-disable no-undef */
+import {createFastestGasPriceFetcher} from './lib/ethgas'
+import {ethgas} from './lib/api'
+import {config} from 'dotenv'
+import {DevCommonInstance} from './lib/instance/common'
+import {Lockup} from './lib/instance/lockup'
+
+config()
+const {CONFIG: configAddress, EGS_TOKEN: egsApiKey} = process.env
+
+const handler = async (
+	callback: (err: Error | null) => void
+): Promise<void> => {
+	if (!configAddress || !egsApiKey) {
+		return
+	}
+
+	const gasFetcher = async () => 6721975
+	const gasPriceFetcher = createFastestGasPriceFetcher(ethgas(egsApiKey), web3)
+	const dev = new DevCommonInstance(
+		artifacts,
+		configAddress,
+		gasFetcher,
+		gasPriceFetcher
+	)
+	await dev.prepare()
+
+	const l = new Lockup(dev)
+	const lCurrent = await l.load()
+	const lNext = await l.create()
+	await l.changeOwner(lCurrent, lNext)
+	await l.set(lNext)
+
+	callback(null)
+}
+
+export = handler

--- a/scripts/632-one-transaction-withdrawal.ts
+++ b/scripts/632-one-transaction-withdrawal.ts
@@ -4,6 +4,7 @@ import {ethgas} from './lib/api'
 import {config} from 'dotenv'
 import {DevCommonInstance} from './lib/instance/common'
 import {Lockup} from './lib/instance/lockup'
+import {PolicyFactory} from './lib/instance/policy-factory'
 
 config()
 const {CONFIG: configAddress, EGS_TOKEN: egsApiKey} = process.env
@@ -30,6 +31,10 @@ const handler = async (
 	const lNext = await l.create()
 	await l.changeOwner(lCurrent, lNext)
 	await l.set(lNext)
+
+	const pf = new PolicyFactory(dev)
+	const pfNext = await pf.create()
+	await pf.set(pfNext)
 
 	callback(null)
 }

--- a/test/dev/dev.ts
+++ b/test/dev/dev.ts
@@ -345,26 +345,6 @@ contract('Dev', ([deployer, user1, user2, marketFactory, market]) => {
 			expect((await dev.lockup.getValue(prop, user1)).toNumber()).to.be.equal(0)
 			expect(res).to.be.an.instanceOf(Error)
 		})
-		it('should fail to lockup token when the sender is waiting for withdrawing', async () => {
-			const dev = await generateEnv()
-			const prop = await createProperty(dev)
-			await dev.metricsGroup.__setMetricsCountPerProperty(prop, 1)
-			await dev.dev.mint(user1, 100)
-			await dev.dev.deposit(prop, 50, {from: user1})
-
-			await dev.lockup.cancel(prop, {from: user1})
-
-			const res = await dev.dev
-				.deposit(prop, 1, {from: user1})
-				.catch((err: Error) => err)
-			const balance = await dev.dev.balanceOf(user1)
-
-			expect(balance.toNumber()).to.be.equal(50)
-			expect((await dev.lockup.getValue(prop, user1)).toNumber()).to.be.equal(
-				50
-			)
-			expect(res).to.be.an.instanceOf(Error)
-		})
 		it('lockup token by running the depositFrom from another account after approved', async () => {
 			const dev = await generateEnv()
 			const prop = await createProperty(dev)

--- a/test/lockup/lockup-storage.ts
+++ b/test/lockup/lockup-storage.ts
@@ -29,17 +29,6 @@ contract('LockupStorageTest', ([property, user]) => {
 			expect(result.toNumber()).to.be.equal(30)
 		})
 	})
-	describe('LockupStorage; setWithdrawalStatus, getWithdrawalStatus', () => {
-		it('Initial value is 0.', async () => {
-			const result = await storage.getStorageWithdrawalStatus(property, user)
-			expect(result.toNumber()).to.be.equal(0)
-		})
-		it('The set value can be taken as it is.', async () => {
-			await storage.setStorageWithdrawalStatusTest(property, user, 3000)
-			const result = await storage.getStorageWithdrawalStatus(property, user)
-			expect(result.toNumber()).to.be.equal(3000)
-		})
-	})
 	describe('LockupStorage; setInterestPrice, getInterestPrice', () => {
 		it('Initial value is 0.', async () => {
 			const result = await storage.getStorageInterestPrice(property)

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -197,7 +197,7 @@ contract('LockupTest', ([deployer, user1]) => {
 			)
 		})
 	})
-	describe.only('Lockup; calculateWithdrawableInterestAmount', () => {
+	describe('Lockup; calculateWithdrawableInterestAmount', () => {
 		type Calculator = (
 			prop: PropertyInstance,
 			account: string,

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -83,17 +83,6 @@ contract('LockupTest', ([deployer, user1]) => {
 		it('should fail to call when a passed value is 0', async () => {
 			const [dev, property] = await init()
 
-			await dev.lockup.changeOwner(deployer)
-			const storage = await dev.lockup
-				.getStorageAddress()
-				.then((x) => artifacts.require('EternalStorage').at(x))
-			await storage.setUint(
-				keccak256('_withdrawalStatus', property.address, deployer),
-				1
-			)
-			await storage.changeOwner(dev.lockup.address)
-			await dev.addressConfig.setToken(deployer)
-
 			const res = await dev.lockup
 				.lockup(deployer, property.address, 0)
 				.catch(err)
@@ -154,18 +143,6 @@ contract('LockupTest', ([deployer, user1]) => {
 				.withdraw(property.address, amount + 1)
 				.catch(err)
 			validateErrorMessage(res, 'insufficient tokens staked')
-		})
-		it('should fail to call when waiting for released', async () => {
-			const [dev, property, policy] = await init()
-
-			const block = await getBlock()
-			await policy.setLockUpBlocks(block + 9999)
-
-			await dev.dev.deposit(property.address, 10000)
-			await mine(5)
-
-			const res = await dev.lockup.withdraw(property.address, 0).catch(err)
-			validateErrorMessage(res, 'waiting for release')
 		})
 		it(`withdraw the amount passed`, async () => {
 			const [dev, property] = await init()

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -83,9 +83,7 @@ contract('LockupTest', ([deployer, user1]) => {
 		it('should fail to call when a passed value is 0', async () => {
 			const [dev, property] = await init()
 
-			const res = await dev.lockup
-				.lockup(deployer, property.address, 0)
-				.catch(err)
+			const res = await dev.dev.deposit(property.address, 0).catch(err)
 			validateErrorMessage(res, 'illegal lockup value')
 		})
 		it(`should fail to call when token's transfer was failed`, async () => {

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -197,7 +197,7 @@ contract('LockupTest', ([deployer, user1]) => {
 			)
 		})
 	})
-	describe('Lockup; calculateWithdrawableInterestAmount', () => {
+	describe.only('Lockup; calculateWithdrawableInterestAmount', () => {
 		type Calculator = (
 			prop: PropertyInstance,
 			account: string,
@@ -605,10 +605,14 @@ contract('LockupTest', ([deployer, user1]) => {
 				})
 			})
 			describe('after withdrawal', () => {
+				let aliceBalance: BigNumber
+				let aliceLocked: BigNumber
 				before(async () => {
+					aliceBalance = await dev.dev.balanceOf(alice).then(toBigNumber)
+					aliceLocked = await dev.lockup.getValue(property.address, alice).then(toBigNumber)
 					await dev.lockup.withdraw(
 						property.address,
-						await dev.lockup.getValue(property.address, alice),
+						aliceLocked,
 						{
 							from: alice,
 						}
@@ -622,11 +626,13 @@ contract('LockupTest', ([deployer, user1]) => {
 					const aliceAmount = await dev.lockup
 						.calculateWithdrawableInterestAmount(property.address, alice)
 						.then(toBigNumber)
-					const expected = toBigNumber(10) // In PolicyTestForLockup, the max staker reward per block is 10.
+					const afterAliceBalance = await dev.dev.balanceOf(alice).then(toBigNumber)
+					const reward = toBigNumber(10) // In PolicyTestForLockup, the max staker reward per block is 10.
 						.times(1e18)
 						.times(block.minus(lastBlock))
+					expect(aliceAmount.toFixed()).to.be.equal('0')
 					expect(aliceLockup.toFixed()).to.be.equal('0')
-					expect(aliceAmount.toFixed()).to.be.equal(expected.toFixed())
+					expect(afterAliceBalance.toFixed()).to.be.equal(aliceBalance.plus(aliceLocked).plus(reward).toFixed())
 				})
 			})
 		})

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -144,7 +144,7 @@ contract('LockupTest', ([deployer, user1]) => {
 			expect(_value).to.be.equal('10000')
 		})
 	})
-	describe.only('Lockup; withdraw', () => {
+	describe('Lockup; withdraw', () => {
 		it('should fail to call when tokens are insufficient', async () => {
 			const [dev, property] = await init()
 			const amount = 1000000

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -1394,6 +1394,7 @@ contract('LockupTest', ([deployer, user1]) => {
 			let lockedAlice: BigNumber
 			let lockedBob: BigNumber
 			let blockAlice: BigNumber
+			let blockBob: BigNumber
 			let legacyLastPriceAlice: BigNumber
 			let legacyLastPriceBob: BigNumber
 			let calc: Calculator
@@ -1496,6 +1497,7 @@ contract('LockupTest', ([deployer, user1]) => {
 					blockAlice = lastBlockAlice
 					await dev.lockup.withdraw(property.address, 0, {from: bob})
 					lastBlockBob = await getBlock().then(toBigNumber)
+					blockBob = lastBlockBob
 					await mine(3)
 				})
 				it('No staked Property is 0 interest', async () => {
@@ -1531,18 +1533,27 @@ contract('LockupTest', ([deployer, user1]) => {
 			})
 			describe('after withdraw', () => {
 				let lastBlockAlice: BigNumber
+				let lastBlockBob: BigNumber
+				let aliceBalance: BigNumber
+				let bobBalance: BigNumber
+				let aliceLocked: BigNumber
+				let bobLocked: BigNumber
 				before(async () => {
-					await dev.lockup.withdraw(
-						property.address,
-						await dev.lockup.getValue(property.address, alice),
-						{from: alice}
-					)
+					aliceBalance = await dev.dev.balanceOf(alice).then(toBigNumber)
+					aliceLocked = await dev.lockup
+						.getValue(property.address, alice)
+						.then(toBigNumber)
+
+					await dev.lockup.withdraw(property.address, aliceLocked, {
+						from: alice,
+					})
 					lastBlockAlice = await getBlock().then(toBigNumber)
-					await dev.lockup.withdraw(
-						property.address,
-						await dev.lockup.getValue(property.address, bob),
-						{from: bob}
-					)
+					bobBalance = await dev.dev.balanceOf(bob).then(toBigNumber)
+					bobLocked = await dev.lockup
+						.getValue(property.address, bob)
+						.then(toBigNumber)
+					await dev.lockup.withdraw(property.address, bobLocked, {from: bob})
+					lastBlockBob = await getBlock().then(toBigNumber)
 					await mine(3)
 				})
 				it('No staked Property is 0 interest', async () => {
@@ -1557,18 +1568,32 @@ contract('LockupTest', ([deployer, user1]) => {
 					const result = await dev.lockup
 						.calculateWithdrawableInterestAmount(property.address, alice)
 						.then(toBigNumber)
-					const expected = toBigNumber(10)
+					const afterAliceBalance = await dev.dev
+						.balanceOf(alice)
+						.then(toBigNumber)
+					const reward = toBigNumber(10)
 						.times(1e18)
 						.times(lastBlockAlice.minus(blockAlice))
 						.times((100000000 * 0.8 + 200000000) / 400000000)
-					expect(result.toFixed()).to.be.equal(expected.toFixed())
+					expect(result.toFixed()).to.be.equal('0')
+					expect(afterAliceBalance.toFixed()).to.be.equal(
+						aliceBalance.plus(aliceLocked).plus(reward).toFixed()
+					)
 				})
 				it(`Bob's withdrawable interest is correct`, async () => {
 					const result = await dev.lockup
 						.calculateWithdrawableInterestAmount(property.address, bob)
 						.then(toBigNumber)
-					const expected = await calc(property, bob)
-					expect(result.toFixed()).to.be.equal(expected.toFixed())
+					const afterBobBalance = await dev.dev.balanceOf(bob).then(toBigNumber)
+					const reward = toBigNumber(10)
+						.times(1e18)
+						.times(lastBlockBob.minus(1).minus(blockBob))
+						.times((100000000 * 0.2 + 100000000) / 400000000)
+						.plus(toBigNumber(10).times(1e18))
+					expect(result.toFixed()).to.be.equal('0')
+					expect(afterBobBalance.toFixed()).to.be.equal(
+						bobBalance.plus(bobLocked).plus(reward).toFixed()
+					)
 				})
 			})
 		})

--- a/test/lockup/lockup.ts
+++ b/test/lockup/lockup.ts
@@ -144,7 +144,7 @@ contract('LockupTest', ([deployer, user1]) => {
 			expect(_value).to.be.equal('10000')
 		})
 	})
-	describe.only('Lockup; withdraw', () => {
+	describe('Lockup; withdraw', () => {
 		it('should fail to call when tokens are not locked', async () => {
 			const [dev, property] = await init()
 
@@ -156,7 +156,9 @@ contract('LockupTest', ([deployer, user1]) => {
 			const amount = 1000000
 			await dev.dev.deposit(property.address, amount)
 
-			const res = await dev.lockup.withdraw(property.address, amount + 1).catch(err)
+			const res = await dev.lockup
+				.withdraw(property.address, amount + 1)
+				.catch(err)
 			validateErrorMessage(res, 'tokens are not staked or insufficient staked')
 		})
 		it('should fail to call when waiting for released', async () => {

--- a/test/policy/policy.ts
+++ b/test/policy/policy.ts
@@ -1,10 +1,7 @@
 contract('Policy', () => {
-	const decimalsLibrary = artifacts.require('Decimals')
 	const policyContract = artifacts.require('PolicyTest1')
 	let policy: any
 	beforeEach(async () => {
-		const decimals = await decimalsLibrary.new()
-		await policyContract.link('Decimals', decimals.address)
 		policy = await policyContract.new()
 	})
 	describe('PolicyTest1; rewards', () => {

--- a/test/withdraw/withdraw.ts
+++ b/test/withdraw/withdraw.ts
@@ -738,10 +738,13 @@ contract('WithdrawTest', ([deployer, user1, user2, user3]) => {
 			describe('after staking withdrawal', () => {
 				let block: BigNumber
 				before(async () => {
-					await dev.lockup.cancel(property.address, {from: carol})
-					await dev.lockup.withdraw(property.address, {
-						from: carol,
-					})
+					await dev.lockup.withdraw(
+						property.address,
+						await dev.lockup.getValue(property.address, carol),
+						{
+							from: carol,
+						}
+					)
 					block = await getBlock().then(toBigNumber)
 				})
 				it(`Alice's withdrawable holders rewards is correct`, async () => {
@@ -830,10 +833,13 @@ contract('WithdrawTest', ([deployer, user1, user2, user3]) => {
 			})
 			describe('after staking withdrawal', () => {
 				it(`Alice's withdrawable holders rewards is correct when also after withdrawal by Carol`, async () => {
-					await dev.lockup.cancel(property.address, {from: carol})
-					await dev.lockup.withdraw(property.address, {
-						from: carol,
-					})
+					await dev.lockup.withdraw(
+						property.address,
+						await dev.lockup.getValue(property.address, carol),
+						{
+							from: carol,
+						}
+					)
 
 					await mine(3)
 					const aliceAmount = await dev.withdraw
@@ -843,10 +849,13 @@ contract('WithdrawTest', ([deployer, user1, user2, user3]) => {
 					expect(aliceAmount.toFixed()).to.be.equal(expected.toFixed())
 				})
 				it(`Alice's withdrawable holders rewards is correct when also after withdrawal by Bob`, async () => {
-					await dev.lockup.cancel(property.address, {from: bob})
-					await dev.lockup.withdraw(property.address, {
-						from: bob,
-					})
+					await dev.lockup.withdraw(
+						property.address,
+						await dev.lockup.getValue(property.address, bob),
+						{
+							from: bob,
+						}
+					)
 					await mine(3)
 					const aliceAmount = await dev.withdraw
 						.calculateWithdrawableAmount(property.address, alice)
@@ -1074,8 +1083,11 @@ contract('WithdrawTest', ([deployer, user1, user2, user3]) => {
 					expect(expected.toFixed()).to.be.equal('0')
 				})
 				it(`Alice's withdrawable holders rewards is correct`, async () => {
-					await dev.lockup.cancel(property1.address, {from: alice})
-					await dev.lockup.withdraw(property1.address, {from: alice})
+					await dev.lockup.withdraw(
+						property1.address,
+						await dev.lockup.getValue(property1.address, alice),
+						{from: alice}
+					)
 					await mine(3)
 					const aliceAmount = await dev.withdraw
 						.calculateWithdrawableAmount(property1.address, alice)
@@ -1084,8 +1096,11 @@ contract('WithdrawTest', ([deployer, user1, user2, user3]) => {
 					expect(aliceAmount.toFixed()).to.be.equal(expected.toFixed())
 				})
 				it(`Bob's withdrawable holders rewards is correct`, async () => {
-					await dev.lockup.cancel(property2.address, {from: alice})
-					await dev.lockup.withdraw(property2.address, {from: alice})
+					await dev.lockup.withdraw(
+						property2.address,
+						await dev.lockup.getValue(property2.address, alice),
+						{from: alice}
+					)
 					await mine(3)
 					const bobAmount = await dev.withdraw
 						.calculateWithdrawableAmount(property2.address, bob)
@@ -1094,8 +1109,11 @@ contract('WithdrawTest', ([deployer, user1, user2, user3]) => {
 					expect(bobAmount.toFixed()).to.be.equal(expected.toFixed())
 				})
 				it(`Carol's withdrawable holders rewards is correct`, async () => {
-					await dev.lockup.cancel(property3.address, {from: alice})
-					await dev.lockup.withdraw(property3.address, {from: alice})
+					await dev.lockup.withdraw(
+						property3.address,
+						await dev.lockup.getValue(property3.address, alice),
+						{from: alice}
+					)
 					await mine(3)
 					const carolAmount = await dev.withdraw
 						.calculateWithdrawableAmount(property3.address, carol)

--- a/test/withdraw/withdraw.ts
+++ b/test/withdraw/withdraw.ts
@@ -49,6 +49,8 @@ contract('WithdrawTest', ([deployer, user1, user2, user3]) => {
 			await dev.dev.addMinter(dev.withdraw.address)
 		}
 
+		await dev.dev.addMinter(dev.lockup.address)
+
 		await dev.dev.mint(deployer, new BigNumber(1e18).times(10000000))
 		await dev.dev.mint(user3, new BigNumber(1e18).times(10000000))
 		const policy = await artifacts.require('PolicyTestForWithdraw').new()


### PR DESCRIPTION
# Description

- Removes the need to pre-run `Lockup.cancel` when unstaking.
- It also offers a partial withdrawal of staking.

# Why

Fixes https://github.com/dev-protocol/DIPs/issues/13 

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
