### PR TITLE
Improvement the way to calculating the cap

### DIFF
--- a/contracts/interface/ILockup.sol
+++ b/contracts/interface/ILockup.sol
@@ -55,5 +55,5 @@ interface ILockup {
 
 	function geometricMeanLockedUp() external view returns (uint256);
 
-	function setGeometricMean(uint256 _geometricMean) external;
+	function updateCap(uint256 _geometricMean) external;
 }

--- a/contracts/interface/IPolicy.sol
+++ b/contracts/interface/IPolicy.sol
@@ -35,5 +35,5 @@ interface IPolicy {
 
 	function treasury() external view returns (address);
 
-	function geometricMeanSetter() external view returns (address);
+	function capSetter() external view returns (address);
 }

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -252,7 +252,7 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 		 * the Property has collected the staking before DIP38 and so sets the value of `getStorageDefaultHoldersRewardCap`.
 		 */
 		if (getStorageInitialCumulativeHoldersRewardCap(_property) == 0) {
-			uint256 hasStaked = getStoragePropertyValue(_property) > 0;
+			bool hasStaked = getStoragePropertyValue(_property) > 0;
 			setStorageInitialCumulativeHoldersRewardCap(
 				_property,
 				hasStaked

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -185,11 +185,34 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 
 	/**
 	 * set geometric average
+	 * TODO: Rename this function
 	 */
 	function setGeometricMean(uint256 _geometricMean) external {
 		address setter = IPolicy(config().policy()).geometricMeanSetter();
 		require(setter == msg.sender, "illegal access");
 		setStorageGeometricMeanLockedUp(_geometricMean);
+
+		/**
+		 * Updates cumulative amount of the holders reward cap
+		 */
+		(, uint256 holdersPrice, , uint256 cCap) =
+			calculateCumulativeRewardPrices();
+
+		// TODO: When this function is improved to be called on-chain, the source of `getStorageLastCumulativeHoldersPriceCap` can be rewritten to` getStorageLastCumulativeHoldersRewardPrice`.
+		uint256 lastHoldersPrice = getStorageLastCumulativeHoldersPriceCap();
+		uint256 additionalCap =
+			holdersPrice.sub(lastHoldersPrice).mul(_geometricMean);
+		uint256 cap = cCap.add(additionalCap);
+		setStorageCumulativeHoldersRewardCap(cap);
+		setStorageLastCumulativeHoldersPriceCap(holdersPrice);
+
+		/**
+		 * Sets the default value on the first update.
+		 * This value is used for Properties that already have collected one or more stakings when DIP38 is applied.
+		 */
+		if (getStorageDefaultHoldersRewardCap() == 0) {
+			setStorageDefaultHoldersRewardCap(cap);
+		}
 	}
 
 	/**
@@ -221,6 +244,12 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 			_property,
 			_prices.holders
 		);
+		if (getStorageInitialCumulativeHoldersRewardCap(_property) == 0) {
+			setStorageInitialCumulativeHoldersRewardCap(
+				_property,
+				_prices.holdersCap
+			);
+		}
 	}
 
 	/**
@@ -240,7 +269,7 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 		uint256 lastHoldersPrice = getStorageLastCumulativeHoldersRewardPrice();
 		uint256 lastInterestPrice = getStorageLastCumulativeInterestPrice();
 		uint256 allStakes = getStorageAllValue();
-		uint256 geometricMean = getStorageGeometricMeanLockedUp();
+		uint256 cCap = getStorageCumulativeHoldersRewardCap();
 
 		/**
 		 * Gets latest cumulative sum of the reward amount.
@@ -266,8 +295,7 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 		 */
 		uint256 holdersPrice = holdersShare.add(lastHoldersPrice);
 		uint256 interestPrice = price.sub(holdersShare).add(lastInterestPrice);
-		uint256 holdersCap = geometricMean.mul(holdersPrice);
-		return (mReward, holdersPrice, interestPrice, holdersCap);
+		return (mReward, holdersPrice, interestPrice, cCap);
 	}
 
 	/**
@@ -326,9 +354,23 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 	{
 		(, uint256 holders, , uint256 holdersCap) =
 			calculateCumulativeRewardPrices();
+		uint256 initialCap =
+			getStorageInitialCumulativeHoldersRewardCap(_property);
+
+		/**
+		 * Calculates the cap
+		 * If `initialCap` exists, subtract its value from `holdersCap`.
+		 * If `initialCap` does not exists, fallback and subtract the value of `getStorageDefaultHoldersRewardCap()`.
+		 */
+		uint256 cap =
+			holdersCap.sub(
+				initialCap > 0
+					? initialCap
+					: getStorageDefaultHoldersRewardCap()
+			);
 		return (
 			_calculateCumulativeHoldersRewardAmount(holders, _property),
-			holdersCap
+			cap
 		);
 	}
 

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -187,7 +187,7 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 	 * set cap
 	 */
 	function updateCap(uint256 _cap) external {
-		address setter = IPolicy(config().policy()).geometricMeanSetter();
+		address setter = IPolicy(config().policy()).capSetter();
 		require(setter == msg.sender, "illegal access");
 		setStorageGeometricMeanLockedUp(_cap);
 

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -205,14 +205,6 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 		uint256 cap = cCap.add(additionalCap);
 		setStorageCumulativeHoldersRewardCap(cap);
 		setStorageLastCumulativeHoldersPriceCap(holdersPrice);
-
-		/**
-		 * Sets the default value on the first update.
-		 * This value is used for Properties that already have collected one or more stakings when DIP38 is applied.
-		 */
-		if (getStorageDefaultHoldersRewardCap() == 0) {
-			setStorageDefaultHoldersRewardCap(cap);
-		}
 	}
 
 	/**
@@ -247,17 +239,11 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 
 		/**
 		 * Sets `InitialCumulativeHoldersRewardCap`.
-		 * If the Property is not staking, sets the latest `holdersCap`.
-		 * If the Property is already staked but the `InitialCumulativeHoldersRewardCap` is 0,
-		 * the Property has collected the staking before DIP38 and so sets the value of `getStorageDefaultHoldersRewardCap`.
 		 */
 		if (getStorageInitialCumulativeHoldersRewardCap(_property) == 0) {
-			bool hasStaked = getStoragePropertyValue(_property) > 0;
 			setStorageInitialCumulativeHoldersRewardCap(
 				_property,
-				hasStaked
-					? getStorageDefaultHoldersRewardCap()
-					: _prices.holdersCap
+				_prices.holdersCap
 			);
 		}
 	}
@@ -369,15 +355,8 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 
 		/**
 		 * Calculates the cap
-		 * If `initialCap` exists, subtract its value from `holdersCap`.
-		 * If `initialCap` does not exists, fallback and subtract the value of `getStorageDefaultHoldersRewardCap()`.
 		 */
-		uint256 cap =
-			holdersCap.sub(
-				initialCap > 0
-					? initialCap
-					: getStorageDefaultHoldersRewardCap()
-			);
+		uint256 cap = holdersCap.sub(initialCap);
 		return (
 			_calculateCumulativeHoldersRewardAmount(holders, _property),
 			cap

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -184,13 +184,12 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 	}
 
 	/**
-	 * set geometric average
-	 * TODO: Rename this function
+	 * set cap
 	 */
-	function setGeometricMean(uint256 _geometricMean) external {
+	function updateCap(uint256 _cap) external {
 		address setter = IPolicy(config().policy()).geometricMeanSetter();
 		require(setter == msg.sender, "illegal access");
-		setStorageGeometricMeanLockedUp(_geometricMean);
+		setStorageGeometricMeanLockedUp(_cap);
 
 		/**
 		 * Updates cumulative amount of the holders reward cap
@@ -201,7 +200,7 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 		// TODO: When this function is improved to be called on-chain, the source of `getStorageLastCumulativeHoldersPriceCap` can be rewritten to` getStorageLastCumulativeHoldersRewardPrice`.
 		uint256 lastHoldersPrice = getStorageLastCumulativeHoldersPriceCap();
 		uint256 additionalCap =
-			holdersPrice.sub(lastHoldersPrice).mul(_geometricMean);
+			holdersPrice.sub(lastHoldersPrice).mul(_cap);
 		uint256 cap = cCap.add(additionalCap);
 		setStorageCumulativeHoldersRewardCap(cap);
 		setStorageLastCumulativeHoldersPriceCap(holdersPrice);

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -244,10 +244,20 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 			_property,
 			_prices.holders
 		);
+
+		/**
+		 * Sets `InitialCumulativeHoldersRewardCap`.
+		 * If the Property is not staking, sets the latest `holdersCap`.
+		 * If the Property is already staked but the `InitialCumulativeHoldersRewardCap` is 0,
+		 * the Property has collected the staking before DIP38 and so sets the value of `getStorageDefaultHoldersRewardCap`.
+		 */
 		if (getStorageInitialCumulativeHoldersRewardCap(_property) == 0) {
+			uint256 hasStaked = getStoragePropertyValue(_property) > 0;
 			setStorageInitialCumulativeHoldersRewardCap(
 				_property,
-				_prices.holdersCap
+				hasStaked
+					? getStorageDefaultHoldersRewardCap()
+					: _prices.holdersCap
 			);
 		}
 	}

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -199,8 +199,7 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 
 		// TODO: When this function is improved to be called on-chain, the source of `getStorageLastCumulativeHoldersPriceCap` can be rewritten to` getStorageLastCumulativeHoldersRewardPrice`.
 		uint256 lastHoldersPrice = getStorageLastCumulativeHoldersPriceCap();
-		uint256 additionalCap =
-			holdersPrice.sub(lastHoldersPrice).mul(_cap);
+		uint256 additionalCap = holdersPrice.sub(lastHoldersPrice).mul(_cap);
 		uint256 cap = cCap.add(additionalCap);
 		setStorageCumulativeHoldersRewardCap(cap);
 		setStorageLastCumulativeHoldersPriceCap(holdersPrice);

--- a/contracts/src/lockup/LockupMigration.sol
+++ b/contracts/src/lockup/LockupMigration.sol
@@ -1,0 +1,43 @@
+pragma solidity 0.5.17;
+
+import {Lockup} from "contracts/src/lockup/Lockup.sol";
+
+contract LockupMigration is Lockup {
+	constructor(address _config) public Lockup(_config) {}
+
+	function lockup(
+		// solhint-disable-next-line no-unused-vars
+		address _from,
+		// solhint-disable-next-line no-unused-vars
+		address _property,
+		// solhint-disable-next-line no-unused-vars
+		uint256 _value
+	) external {
+		require(false, "under maintenance");
+	}
+
+	// solhint-disable-next-line no-unused-vars
+	function withdraw(address _property, uint256 _amount) external {
+		require(false, "under maintenance");
+	}
+
+	function setInitialCumulativeHoldersRewardCap(address _property)
+		external
+		onlyOwner
+	{
+		/**
+		 * Validates the value is not set.
+		 */
+		require(
+			getStorageInitialCumulativeHoldersRewardCap(_property) == 0,
+			"already set the value"
+		);
+
+		uint256 cCap = getStorageCumulativeHoldersRewardCap();
+
+		/**
+		 * Sets the value.
+		 */
+		setStorageInitialCumulativeHoldersRewardCap(_property, cCap);
+	}
+}

--- a/contracts/src/lockup/LockupStorage.sol
+++ b/contracts/src/lockup/LockupStorage.sol
@@ -556,24 +556,4 @@ contract LockupStorage is UsingStorage {
 				)
 			);
 	}
-
-	//DefaultHoldersRewardCap
-	function setStorageDefaultHoldersRewardCap(uint256 _value) internal {
-		eternalStorage().setUint(
-			getStorageDefaultHoldersRewardCapKey(),
-			_value
-		);
-	}
-
-	function getStorageDefaultHoldersRewardCap() public view returns (uint256) {
-		return eternalStorage().getUint(getStorageDefaultHoldersRewardCapKey());
-	}
-
-	function getStorageDefaultHoldersRewardCapKey()
-		private
-		pure
-		returns (bytes32)
-	{
-		return keccak256(abi.encodePacked("_defaultHoldersRewardCap"));
-	}
 }

--- a/contracts/src/lockup/LockupStorage.sol
+++ b/contracts/src/lockup/LockupStorage.sol
@@ -468,4 +468,112 @@ contract LockupStorage is UsingStorage {
 	{
 		return keccak256(abi.encodePacked("_disabledLockedups", _property));
 	}
+
+	//CumulativeHoldersRewardCap
+	function setStorageCumulativeHoldersRewardCap(uint256 _value) internal {
+		eternalStorage().setUint(
+			getStorageCumulativeHoldersRewardCapKey(),
+			_value
+		);
+	}
+
+	function getStorageCumulativeHoldersRewardCap()
+		public
+		view
+		returns (uint256)
+	{
+		return
+			eternalStorage().getUint(getStorageCumulativeHoldersRewardCapKey());
+	}
+
+	function getStorageCumulativeHoldersRewardCapKey()
+		private
+		pure
+		returns (bytes32)
+	{
+		return keccak256(abi.encodePacked("_cumulativeHoldersRewardCap"));
+	}
+
+	//LastCumulativeHoldersPriceCap
+	function setStorageLastCumulativeHoldersPriceCap(uint256 _value) internal {
+		eternalStorage().setUint(
+			getStorageLastCumulativeHoldersPriceCapKey(),
+			_value
+		);
+	}
+
+	function getStorageLastCumulativeHoldersPriceCap()
+		public
+		view
+		returns (uint256)
+	{
+		return
+			eternalStorage().getUint(
+				getStorageLastCumulativeHoldersPriceCapKey()
+			);
+	}
+
+	function getStorageLastCumulativeHoldersPriceCapKey()
+		private
+		pure
+		returns (bytes32)
+	{
+		return keccak256(abi.encodePacked("_lastCumulativeHoldersPriceCap"));
+	}
+
+	//InitialCumulativeHoldersRewardCap
+	function setStorageInitialCumulativeHoldersRewardCap(
+		address _property,
+		uint256 _value
+	) internal {
+		eternalStorage().setUint(
+			getStorageInitialCumulativeHoldersRewardCapKey(_property),
+			_value
+		);
+	}
+
+	function getStorageInitialCumulativeHoldersRewardCap(address _property)
+		public
+		view
+		returns (uint256)
+	{
+		return
+			eternalStorage().getUint(
+				getStorageInitialCumulativeHoldersRewardCapKey(_property)
+			);
+	}
+
+	function getStorageInitialCumulativeHoldersRewardCapKey(address _property)
+		private
+		pure
+		returns (bytes32)
+	{
+		return
+			keccak256(
+				abi.encodePacked(
+					"_initialCumulativeHoldersRewardCap",
+					_property
+				)
+			);
+	}
+
+	//DefaultHoldersRewardCap
+	function setStorageDefaultHoldersRewardCap(uint256 _value) internal {
+		eternalStorage().setUint(
+			getStorageDefaultHoldersRewardCapKey(),
+			_value
+		);
+	}
+
+	function getStorageDefaultHoldersRewardCap() public view returns (uint256) {
+		return eternalStorage().getUint(getStorageDefaultHoldersRewardCapKey());
+	}
+
+	function getStorageDefaultHoldersRewardCapKey()
+		private
+		pure
+		returns (bytes32)
+	{
+		return keccak256(abi.encodePacked("_defaultHoldersRewardCap"));
+	}
 }

--- a/contracts/src/policy/DIP1.sol
+++ b/contracts/src/policy/DIP1.sol
@@ -110,7 +110,7 @@ contract DIP1 is IPolicy, UsingConfig {
 		return address(0);
 	}
 
-	function geometricMeanSetter() external view returns (address) {
+	function capSetter() external view returns (address) {
 		return address(0);
 	}
 }

--- a/contracts/src/policy/GeometricMean.sol
+++ b/contracts/src/policy/GeometricMean.sol
@@ -8,15 +8,15 @@ import {TreasuryFee} from "contracts/src/policy/TreasuryFee.sol";
  * GeometricMean is a contract that changes the `rewards` of DIP7.
  */
 contract GeometricMean is TreasuryFee {
-	address private geometricMeanSetterAddress;
+	address private capSetterAddress;
 
 	constructor(address _config) public TreasuryFee(_config) {}
 
-	function setGeometricMeanSetter(address _setter) external onlyOwner {
-		geometricMeanSetterAddress = _setter;
+	function setCapSetter(address _setter) external onlyOwner {
+		capSetterAddress = _setter;
 	}
 
-	function geometricMeanSetter() external view returns (address) {
-		return geometricMeanSetterAddress;
+	function capSetter() external view returns (address) {
+		return capSetterAddress;
 	}
 }

--- a/contracts/src/policy/TheFirstPolicy.sol
+++ b/contracts/src/policy/TheFirstPolicy.sol
@@ -110,7 +110,7 @@ contract TheFirstPolicy is IPolicy, UsingConfig {
 		return address(0);
 	}
 
-	function geometricMeanSetter() external view returns (address) {
+	function capSetter() external view returns (address) {
 		return address(0);
 	}
 }

--- a/contracts/test/lockup/LockupMigrationTest.sol
+++ b/contracts/test/lockup/LockupMigrationTest.sol
@@ -1,0 +1,11 @@
+pragma solidity 0.5.17;
+
+import {LockupMigration} from "contracts/src/lockup/LockupMigration.sol";
+
+contract LockupMigrationTest is LockupMigration {
+	constructor(address _config) public LockupMigration(_config) {}
+
+	function prepare() external {
+		setStorageCumulativeHoldersRewardCap(10);
+	}
+}

--- a/contracts/test/lockup/LockupStorageTest.sol
+++ b/contracts/test/lockup/LockupStorageTest.sol
@@ -105,4 +105,22 @@ contract LockupStorageTest is LockupStorage {
 	{
 		setStorageDisabledLockedups(_property, _value);
 	}
+
+	function setStorageCumulativeHoldersRewardCapTest(uint256 _value)
+		external
+	{
+		setStorageCumulativeHoldersRewardCap(_value);
+	}
+
+	function setStorageLastCumulativeHoldersPriceCapTest(uint256 _value)
+		external
+	{
+		setStorageLastCumulativeHoldersPriceCap(_value);
+	}
+
+	function setStorageInitialCumulativeHoldersRewardCapTest(address _property, uint256 _value)
+		external
+	{
+		setStorageInitialCumulativeHoldersRewardCap(_property, _value);
+	}
 }

--- a/contracts/test/lockup/LockupStorageTest.sol
+++ b/contracts/test/lockup/LockupStorageTest.sol
@@ -106,9 +106,7 @@ contract LockupStorageTest is LockupStorage {
 		setStorageDisabledLockedups(_property, _value);
 	}
 
-	function setStorageCumulativeHoldersRewardCapTest(uint256 _value)
-		external
-	{
+	function setStorageCumulativeHoldersRewardCapTest(uint256 _value) external {
 		setStorageCumulativeHoldersRewardCap(_value);
 	}
 
@@ -118,9 +116,10 @@ contract LockupStorageTest is LockupStorage {
 		setStorageLastCumulativeHoldersPriceCap(_value);
 	}
 
-	function setStorageInitialCumulativeHoldersRewardCapTest(address _property, uint256 _value)
-		external
-	{
+	function setStorageInitialCumulativeHoldersRewardCapTest(
+		address _property,
+		uint256 _value
+	) external {
 		setStorageInitialCumulativeHoldersRewardCap(_property, _value);
 	}
 }

--- a/contracts/test/policy/PolicyTestBase.sol
+++ b/contracts/test/policy/PolicyTestBase.sol
@@ -6,7 +6,7 @@ import {IPolicy} from "contracts/interface/IPolicy.sol";
 contract PolicyTestBase is IPolicy {
 	using SafeMath for uint256;
 	address public treasury;
-	address public geometricMeanSetter;
+	address public capSetter;
 
 	// solhint-disable-next-line no-unused-vars
 	function rewards(uint256 _lockups, uint256 _assets)
@@ -71,7 +71,7 @@ contract PolicyTestBase is IPolicy {
 		treasury = _treasury;
 	}
 
-	function setGeometricMeanSetter(address _geometricMeanSetter) external {
-		geometricMeanSetter = _geometricMeanSetter;
+	function setCapSetter(address _capSetter) external {
+		capSetter = _capSetter;
 	}
 }

--- a/scripts/dip38.ts
+++ b/scripts/dip38.ts
@@ -43,7 +43,7 @@ const handler = async (
 	const nextPolicy = await artifacts
 		.require('GeometricMean')
 		.new(dev.addressConfig.address)
-	await nextPolicy.setGeometricMeanSetter(geometricMearSetter)
+	await nextPolicy.setCapSetter(geometricMearSetter)
 	await nextPolicy.setTreasury(treasuryAddress)
 
 	const policyFactory = new PolicyFactory(dev)

--- a/test/lockup/lockup-migration.ts
+++ b/test/lockup/lockup-migration.ts
@@ -1,0 +1,64 @@
+import { LockupMigrationTestInstance } from '../../types/truffle-contracts'
+import { validateErrorMessage } from '../test-lib/utils/error'
+
+contract('LockupMigrationTest', ([from, property, user]) => {
+	const err = (error: Error): Error => error
+
+	const init = async (): Promise<LockupMigrationTestInstance> => {
+		const config = await artifacts.require('AddressConfig').new()
+		const lockup = await artifacts
+			.require('LockupMigrationTest')
+			.new(config.address)
+		await lockup.createStorage()
+		await lockup.prepare()
+		return lockup
+	}
+
+	describe('LockupMigration; lockup', () => {
+		it('There will always be an error.', async () => {
+			const lockup = await init()
+			const res = await lockup.lockup(from, property, 10).catch(err)
+			validateErrorMessage(res, 'under maintenance')
+		})
+	})
+	describe('LockupMigration; withdraw', () => {
+		it('There will always be an error.', async () => {
+			const lockup = await init()
+			const res = await lockup.withdraw(property, 10).catch(err)
+			validateErrorMessage(res, 'under maintenance')
+		})
+	})
+	describe('LockupMigration; setInitialCumulativeHoldersRewardCap', () => {
+		describe('success', () => {
+			it('The value of cap will be set..', async () => {
+				const lockup = await init()
+				const before = await lockup.getStorageInitialCumulativeHoldersRewardCap(
+					property
+				)
+				expect(before.toNumber()).to.be.equal(0)
+				await lockup.setInitialCumulativeHoldersRewardCap(property)
+				const after = await lockup.getStorageInitialCumulativeHoldersRewardCap(
+					property
+				)
+				expect(after.toNumber()).to.be.equal(10)
+			})
+		})
+		describe('fail', () => {
+			it('An error will occur if anyone other than the owner runs it.', async () => {
+				const lockup = await init()
+				const res = await lockup
+					.setInitialCumulativeHoldersRewardCap(property, { from: user })
+					.catch(err)
+				validateErrorMessage(res, 'Ownable: caller is not the owner')
+			})
+			it('If it has already been executed, it will result in an error..', async () => {
+				const lockup = await init()
+				await lockup.setInitialCumulativeHoldersRewardCap(property)
+				const res = await lockup
+					.setInitialCumulativeHoldersRewardCap(property)
+					.catch(err)
+				validateErrorMessage(res, 'already set the value')
+			})
+		})
+	})
+})

--- a/test/lockup/lockup-storage.ts
+++ b/test/lockup/lockup-storage.ts
@@ -226,4 +226,47 @@ contract('LockupStorageTest', ([property, user]) => {
 			expect(result.toNumber()).to.be.equal(900000000000)
 		})
 	})
+
+	describe('LockupStorage; setStorageCumulativeHoldersRewardCap, getStorageCumulativeHoldersRewardCap', () => {
+		it('Initial value is 0 and 0.', async () => {
+			const result = await storage.getStorageCumulativeHoldersRewardCap()
+			expect(result.toNumber()).to.be.equal(0)
+		})
+		it('The set value can be taken as it is.', async () => {
+			await storage.setStorageCumulativeHoldersRewardCapTest(200000000000)
+			const result = await storage.getStorageCumulativeHoldersRewardCap()
+			expect(result.toNumber()).to.be.equal(200000000000)
+		})
+	})
+
+	describe('LockupStorage; setStorageLastCumulativeHoldersPriceCap, getStorageLastCumulativeHoldersPriceCap', () => {
+		it('Initial value is 0 and 0.', async () => {
+			const result = await storage.getStorageLastCumulativeHoldersPriceCap()
+			expect(result.toNumber()).to.be.equal(0)
+		})
+		it('The set value can be taken as it is.', async () => {
+			await storage.setStorageLastCumulativeHoldersPriceCapTest(100000000000)
+			const result = await storage.getStorageLastCumulativeHoldersPriceCap()
+			expect(result.toNumber()).to.be.equal(100000000000)
+		})
+	})
+
+	describe('LockupStorage; setStorageInitialCumulativeHoldersRewardCap, getStorageInitialCumulativeHoldersRewardCap', () => {
+		it('Initial value is 0 and 0.', async () => {
+			const result = await storage.getStorageInitialCumulativeHoldersRewardCap(
+				property
+			)
+			expect(result.toNumber()).to.be.equal(0)
+		})
+		it('The set value can be taken as it is.', async () => {
+			await storage.setStorageInitialCumulativeHoldersRewardCapTest(
+				property,
+				800000000000
+			)
+			const result = await storage.getStorageInitialCumulativeHoldersRewardCap(
+				property
+			)
+			expect(result.toNumber()).to.be.equal(800000000000)
+		})
+	})
 })

--- a/test/policy/dip1.ts
+++ b/test/policy/dip1.ts
@@ -183,7 +183,7 @@ contract('DIP1', ([deployer]) => {
 	})
 	describe('DIP1; geometricMeanSetter', () => {
 		it('geometricMeanSetter equals TheFirstPolicy', async () => {
-			const method = 'geometricMeanSetter'
+			const method = 'capSetter'
 			expect((await dip1[method]()).toString()).to.be.equal(
 				(await theFirstPolicy[method]()).toString()
 			)

--- a/test/policy/dip1.ts
+++ b/test/policy/dip1.ts
@@ -181,8 +181,8 @@ contract('DIP1', ([deployer]) => {
 			)
 		})
 	})
-	describe('DIP1; geometricMeanSetter', () => {
-		it('geometricMeanSetter equals TheFirstPolicy', async () => {
+	describe('DIP1; capSetter', () => {
+		it('capSetter equals TheFirstPolicy', async () => {
 			const method = 'capSetter'
 			expect((await dip1[method]()).toString()).to.be.equal(
 				(await theFirstPolicy[method]()).toString()

--- a/test/policy/dip7.ts
+++ b/test/policy/dip7.ts
@@ -250,9 +250,9 @@ contract('DIP7', ([deployer]) => {
 			)
 		})
 	})
-	describe('DIP1; geometricMeanSetter', () => {
+	describe('DIP1; capSetter', () => {
 		it('treasury equals DIP1', async () => {
-			const method = 'geometricMeanSetter'
+			const method = 'capSetter'
 			expect((await dip7[method]()).toString()).to.be.equal(
 				(await dip1[method]()).toString()
 			)

--- a/test/policy/geometric-mean.ts
+++ b/test/policy/geometric-mean.ts
@@ -7,7 +7,7 @@ import { DevProtocolInstance } from '../test-lib/instance'
 import BigNumber from 'bignumber.js'
 import { batchRandom } from './utils'
 import { validateNotOwnerErrorMessage } from '../test-lib/utils/error'
-contract('GeometricMean', ([deployer, treasury, geometricMeanSetter, uesr]) => {
+contract('GeometricMean', ([deployer, treasury, capSetter, uesr]) => {
 	let treasuryFee: TreasuryFeeInstance
 	let geometricMean: GeometricMeanInstance
 	let dev: DevProtocolInstance
@@ -218,22 +218,22 @@ contract('GeometricMean', ([deployer, treasury, geometricMeanSetter, uesr]) => {
 			validateNotOwnerErrorMessage(result)
 		})
 	})
-	describe('GeometricMean; geometricMeanSetter', () => {
+	describe('GeometricMean; capSetter', () => {
 		it('returns the setter address.', async () => {
-			await geometricMean.setGeometricMeanSetter(geometricMeanSetter)
-			const result = await geometricMean.geometricMeanSetter()
-			expect(result).to.be.equal(geometricMeanSetter)
+			await geometricMean.setCapSetter(capSetter)
+			const result = await geometricMean.capSetter()
+			expect(result).to.be.equal(capSetter)
 		})
 		it('the default value is 0 address.', async () => {
 			const treasuryFeeTmp = await artifacts
 				.require('TreasuryFee')
 				.new(dev.addressConfig.address)
-			const result = await treasuryFeeTmp.geometricMeanSetter()
+			const result = await treasuryFeeTmp.capSetter()
 			expect(result).to.be.equal(DEFAULT_ADDRESS)
 		})
 		it('No one but the owner can set the address.', async () => {
 			const result = await geometricMean
-				.setGeometricMeanSetter(geometricMeanSetter, {
+				.setCapSetter(capSetter, {
 					from: uesr,
 				})
 				.catch((err: Error) => err)

--- a/test/policy/policy.ts
+++ b/test/policy/policy.ts
@@ -59,10 +59,10 @@ contract('Policy', ([account1, account2]) => {
 			expect(tmp).to.be.equal(account1)
 		})
 	})
-	describe('PolicyTest1; setGeometricMeanSetter', () => {
+	describe('PolicyTest1; setCapSetter', () => {
 		it('get the set geometric mean setter address', async () => {
-			await policy.setGeometricMeanSetter(account2)
-			const tmp: string = await policy.geometricMeanSetter()
+			await policy.setCapSetter(account2)
+			const tmp: string = await policy.capSetter()
 			expect(tmp).to.be.equal(account2)
 		})
 	})

--- a/test/policy/the-first-policy.ts
+++ b/test/policy/the-first-policy.ts
@@ -223,10 +223,10 @@ contract('TheFirstPolicy', ([deployer]) => {
 			expect(result.toString()).to.be.equal(DEFAULT_ADDRESS)
 		})
 	})
-	describe('TheFirstPolicy; geometricMeanSetter', () => {
-		it('Returns the geometricMeanSetter address', async () => {
+	describe('TheFirstPolicy; capSetter', () => {
+		it('Returns the capSetter address', async () => {
 			const policy = await create()
-			const result = await policy.geometricMeanSetter()
+			const result = await policy.capSetter()
 			expect(result.toString()).to.be.equal(DEFAULT_ADDRESS)
 		})
 	})

--- a/test/property/property-factory.ts
+++ b/test/property/property-factory.ts
@@ -24,11 +24,13 @@ contract(
 			before(async () => {
 				await dev.generateAddressConfig()
 				await Promise.all([
+					dev.generateAllocator(),
 					dev.generatePropertyFactory(),
 					dev.generatePropertyGroup(),
 					dev.generatePolicyFactory(),
 					dev.generatePolicyGroup(),
 					dev.generateLockup(),
+					dev.generateMetricsGroup(),
 				])
 				await dev.generatePolicy()
 				await dev.addressConfig.setMarketFactory(marketFactory)

--- a/test/property/property.ts
+++ b/test/property/property.ts
@@ -15,6 +15,8 @@ contract(
 			const dev = new DevProtocolInstance(deployer)
 			before(async () => {
 				await dev.generateAddressConfig()
+				await dev.generateAllocator()
+				await dev.generateMetricsGroup()
 				await dev.generatePolicyFactory()
 				await dev.generatePolicyGroup()
 				await dev.generateLockup()
@@ -66,6 +68,8 @@ contract(
 			const dev = new DevProtocolInstance(deployer)
 			before(async () => {
 				await dev.generateAddressConfig()
+				await dev.generateAllocator()
+				await dev.generateMetricsGroup()
 				await dev.generatePolicyFactory()
 				await dev.generatePolicyGroup()
 				await dev.generateLockup()
@@ -111,6 +115,8 @@ contract(
 			beforeEach(async () => {
 				await dev.generateAddressConfig()
 				await Promise.all([
+					dev.generateAllocator(),
+					dev.generateMetricsGroup(),
 					dev.generatePropertyGroup(),
 					dev.generatePropertyFactory(),
 					dev.generateDev(),

--- a/test/test-lib/instance.ts
+++ b/test/test-lib/instance.ts
@@ -297,8 +297,8 @@ export class DevProtocolInstance {
 		)
 		await policy.setTreasury(this._treasury.address)
 		await this._policyFactory.create(policy.address)
-		await policy.setGeometricMeanSetter(this._deployer)
-		await this.setDefaultGeometricMean()
+		await policy.setCapSetter(this._deployer)
+		await this.updateCap()
 		return policy.address
 	}
 
@@ -327,9 +327,9 @@ export class DevProtocolInstance {
 		return contract('Metrics').new(market, property)
 	}
 
-	public async setDefaultGeometricMean(
+	private async updateCap(
 		value = '115792089237316000000000000000000000'
 	): Promise<void> {
-		await this._lockup.setGeometricMean(value)
+		await this._lockup.updateCap(value)
 	}
 }


### PR DESCRIPTION
# Description

I improved the formulas for calculating the withdrawal cap by DIP38.

This change will result in minor specification changes as follows:

- For Properties that collect staking for the first time after DIP38, the cap will be calculated from the time at that staking.
- For Properties that collected staking before DIP38, the cap will be calculated from the time at DIP38 deployment.

The most symbolic changes are:
https://github.com/dev-protocol/protocol/blob/51b53e6049431dca1c61b5cf83e96692455a751e/contracts/src/lockup/Lockup.sol#L360-L370

# Why

This change eliminates the need to perform off-chain bulk updates for storage values when deploying DIP38. It can also set a withdrawal limit for all Property rewards at the time DIP38 is deployed.

# Related Issues

Fixes # .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
