### PR TITLE
"Property Renaming" and "Symbol Renaming"

### DIFF
--- a/contracts/interface/IProperty.sol
+++ b/contracts/interface/IProperty.sol
@@ -6,5 +6,9 @@ interface IProperty {
 
 	function changeAuthor(address _nextAuthor) external;
 
+	function changeName(string calldata _name) external;
+
+	function changeSymbol(string calldata _symbol) external;
+
 	function withdraw(address _sender, uint256 _value) external;
 }

--- a/contracts/interface/IPropertyFactory.sol
+++ b/contracts/interface/IPropertyFactory.sol
@@ -17,5 +17,11 @@ interface IPropertyFactory {
 		string calldata _args3
 	) external returns (bool);
 
-	function createChangeAuthorEvent(address _before, address _after) external;
+	function createChangeAuthorEvent(address _old, address _new) external;
+
+	function createChangeNameEvent(string calldata _old, string calldata _new)
+		external;
+
+	function createChangeSymbolEvent(string calldata _old, string calldata _new)
+		external;
 }

--- a/contracts/src/property/Property.sol
+++ b/contracts/src/property/Property.sol
@@ -23,7 +23,11 @@ contract Property is ERC20, UsingConfig, IProperty {
 	uint8 private __decimals;
 
 	/**
-	 * Initializes the passed value as AddressConfig address, author address, token name, and token symbol.
+	 * @dev Initializes the passed value as AddressConfig address, author address, token name, and token symbol.
+	 * @param _config AddressConfig address.
+	 * @param _own The author address.
+	 * @param _name The name of the new Property.
+	 * @param _symbol The symbol of the new Property.
 	 */
 	constructor(
 		address _config,

--- a/contracts/src/property/Property.sol
+++ b/contracts/src/property/Property.sol
@@ -2,8 +2,6 @@ pragma solidity 0.5.17;
 
 import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-// prettier-ignore
-import {ERC20Detailed} from "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
 import {UsingConfig} from "contracts/src/common/config/UsingConfig.sol";
 import {IAllocator} from "contracts/interface/IAllocator.sol";
 import {IProperty} from "contracts/interface/IProperty.sol";
@@ -15,11 +13,14 @@ import {IPolicy} from "contracts/interface/IPolicy.sol";
  * Property contract inherits ERC20.
  * Holders of Property contracts(tokens) receive holder rewards according to their share.
  */
-contract Property is ERC20, ERC20Detailed, UsingConfig, IProperty {
+contract Property is ERC20, UsingConfig, IProperty {
 	using SafeMath for uint256;
 	uint8 private constant PROPERTY_DECIMALS = 18;
 	uint256 private constant SUPPLY = 10000000000000000000000000;
-	address public author;
+	address private __author;
+	string private __name;
+	string private __symbol;
+	uint8 private __decimals;
 
 	/**
 	 * Initializes the passed value as AddressConfig address, author address, token name, and token symbol.
@@ -29,11 +30,7 @@ contract Property is ERC20, ERC20Detailed, UsingConfig, IProperty {
 		address _own,
 		string memory _name,
 		string memory _symbol
-	)
-		public
-		UsingConfig(_config)
-		ERC20Detailed(_name, _symbol, PROPERTY_DECIMALS)
-	{
+	) public UsingConfig(_config) {
 		/**
 		 * Validates the sender is PropertyFactory contract.
 		 */
@@ -44,7 +41,14 @@ contract Property is ERC20, ERC20Detailed, UsingConfig, IProperty {
 		/**
 		 * Sets the author.
 		 */
-		author = _own;
+		__author = _own;
+
+		/**
+		 * Sets the ERO20 attributes
+		 */
+		__name = _name;
+		__symbol = _symbol;
+		__decimals = PROPERTY_DECIMALS;
 
 		/**
 		 * Mints to the author and  treasury contract.
@@ -53,35 +57,108 @@ contract Property is ERC20, ERC20Detailed, UsingConfig, IProperty {
 		uint256 toTreasury = policy.shareOfTreasury(SUPPLY);
 		uint256 toAuthor = SUPPLY.sub(toTreasury);
 		require(toAuthor != 0, "share of author is 0");
-		_mint(author, toAuthor);
+		_mint(__author, toAuthor);
 		_mint(policy.treasury(), toTreasury);
 	}
 
 	/**
-	 * Changing the author
+	 * @dev Throws if called by any account other than the author.
 	 */
-	function changeAuthor(address _nextAuthor) external {
-		/**
-		 * Validates the sender is current author.
-		 */
-		require(msg.sender == author, "illegal sender");
+	modifier onlyAuthor() {
+		require(msg.sender == __author, "illegal sender");
+		_;
+	}
 
+	/**
+	 * @dev Returns the name of the author.
+	 * @return The the author address.
+	 */
+	function author() external view returns (address) {
+		return __author;
+	}
+
+	/**
+	 * @dev Returns the name of the token.
+	 * @return The name of the token.
+	 */
+	function name() external view returns (string memory) {
+		return __name;
+	}
+
+	/**
+	 * @dev Returns the symbol of the token, usually a shorter version of the name.
+	 * @return The symbol of the token, usually a shorter version of the name.
+	 */
+	function symbol() external view returns (string memory) {
+		return __symbol;
+	}
+
+	/**
+	 * @dev Returns the number of decimals used to get its user representation.
+	 * For example, if `decimals` equals `2`, a balance of `505` tokens should
+	 * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+	 *
+	 * Tokens usually opt for a value of 18, imitating the relationship between
+	 * Ether and Wei.
+	 *
+	 * NOTE: This information is only used for _display_ purposes: it in
+	 * no way affects any of the arithmetic of the contract, including
+	 * {IERC20-balanceOf} and {IERC20-transfer}.
+	 * @return The number of decimals used to get its user representation.
+	 */
+	function decimals() external view returns (uint8) {
+		return __decimals;
+	}
+
+	/**
+	 * @dev Changes the author.
+	 * @param _nextAuthor The new author address.
+	 */
+	function changeAuthor(address _nextAuthor) external onlyAuthor {
 		/**
 		 * save author information
 		 */
 		IPropertyFactory(config().propertyFactory()).createChangeAuthorEvent(
-			author,
+			__author,
 			_nextAuthor
 		);
 
 		/**
 		 * Changes the author.
 		 */
-		author = _nextAuthor;
+		__author = _nextAuthor;
 	}
 
 	/**
-	 * Hook on `transfer` and call `Withdraw.beforeBalanceChange` function.
+	 * @dev Changes the name.
+	 * @param _name The new name.
+	 */
+	function changeName(string calldata _name) external onlyAuthor {
+		IPropertyFactory(config().propertyFactory()).createChangeNameEvent(
+			__name,
+			_name
+		);
+
+		__name = _name;
+	}
+
+	/**
+	 * @dev Changes the symbol.
+	 * @param _symbol The new symbol.
+	 */
+	function changeSymbol(string calldata _symbol) external onlyAuthor {
+		IPropertyFactory(config().propertyFactory()).createChangeSymbolEvent(
+			__symbol,
+			_symbol
+		);
+
+		__symbol = _symbol;
+	}
+
+	/**
+	 * @dev Hook on `transfer` and call `Withdraw.beforeBalanceChange` function.
+	 * @param _to The recipient address.
+	 * @param _value The transfer amount.
 	 */
 	function transfer(address _to, uint256 _value) public returns (bool) {
 		/**
@@ -108,7 +185,10 @@ contract Property is ERC20, ERC20Detailed, UsingConfig, IProperty {
 	}
 
 	/**
-	 * Hook on `transferFrom` and call `Withdraw.beforeBalanceChange` function.
+	 * @dev Hook on `transferFrom` and call `Withdraw.beforeBalanceChange` function.
+	 * @param _from The source address.
+	 * @param _to The recipient address.
+	 * @param _value The transfer amount.
 	 */
 	function transferFrom(
 		address _from,
@@ -153,7 +233,9 @@ contract Property is ERC20, ERC20Detailed, UsingConfig, IProperty {
 	}
 
 	/**
-	 * Transfers the staking amount to the original owner.
+	 * @dev Transfers the staking amount to the original owner.
+	 * @param _sender The Property Contract address as the source.
+	 * @param _value The transfer amount.
 	 */
 	function withdraw(address _sender, uint256 _value) external {
 		/**

--- a/contracts/src/property/PropertyFactory.sol
+++ b/contracts/src/property/PropertyFactory.sol
@@ -16,6 +16,8 @@ contract PropertyFactory is UsingConfig, IPropertyFactory {
 		address _beforeAuthor,
 		address _afterAuthor
 	);
+	event ChangeName(address indexed _property, string _old, string _new);
+	event ChangeSymbol(address indexed _property, string _old, string _new);
 
 	/**
 	 * Initialize the passed address as AddressConfig address.
@@ -80,15 +82,34 @@ contract PropertyFactory is UsingConfig, IPropertyFactory {
 		return address(property);
 	}
 
-	function createChangeAuthorEvent(
-		address _beforeAuthor,
-		address _afterAuthor
-	) external {
+	function createChangeAuthorEvent(address _old, address _new) external {
 		require(
 			IPropertyGroup(config().propertyGroup()).isGroup(msg.sender),
 			"this is illegal address"
 		);
 
-		emit ChangeAuthor(msg.sender, _beforeAuthor, _afterAuthor);
+		emit ChangeAuthor(msg.sender, _old, _new);
+	}
+
+	function createChangeNameEvent(string calldata _old, string calldata _new)
+		external
+	{
+		require(
+			IPropertyGroup(config().propertyGroup()).isGroup(msg.sender),
+			"this is illegal address"
+		);
+
+		emit ChangeName(msg.sender, _old, _new);
+	}
+
+	function createChangeSymbolEvent(string calldata _old, string calldata _new)
+		external
+	{
+		require(
+			IPropertyGroup(config().propertyGroup()).isGroup(msg.sender),
+			"this is illegal address"
+		);
+
+		emit ChangeSymbol(msg.sender, _old, _new);
 	}
 }

--- a/contracts/src/property/PropertyFactory.sol
+++ b/contracts/src/property/PropertyFactory.sol
@@ -20,12 +20,28 @@ contract PropertyFactory is UsingConfig, IPropertyFactory {
 	event ChangeSymbol(address indexed _property, string _old, string _new);
 
 	/**
-	 * Initialize the passed address as AddressConfig address.
+	 * @dev Initialize the passed address as AddressConfig address.
+	 * @param _config AddressConfig address.
 	 */
 	constructor(address _config) public UsingConfig(_config) {}
 
 	/**
-	 * Creates a new Property contract.
+	 * @dev Throws if called by any account other than Properties.
+	 */
+	modifier onlyProperty() {
+		require(
+			IPropertyGroup(config().propertyGroup()).isGroup(msg.sender),
+			"illegal address"
+		);
+		_;
+	}
+
+	/**
+	 * @dev Creates a new Property contract.
+	 * @param _name Name of the new Property.
+	 * @param _symbol Symbol of the new Property.
+	 * @param _author Author address of the new Property.
+	 * @return Address of the new Property.
 	 */
 	function create(
 		string calldata _name,
@@ -36,8 +52,15 @@ contract PropertyFactory is UsingConfig, IPropertyFactory {
 	}
 
 	/**
-	 * Creates a new Property contract and authenticate.
+	 * @dev Creates a new Property contract and authenticate.
 	 * There are too many local variables, so when using this method limit the number of arguments that can be used to authenticate to a maximum of 3.
+	 * @param _name Name of the new Property.
+	 * @param _symbol Symbol of the new Property.
+	 * @param _market Address of a Market.
+	 * @param _args1 First argument to pass through to Market.
+	 * @param _args2 Second argument to pass through to Market.
+	 * @param _args3 Third argument to pass through to Market.
+	 * @return The transaction fail/success.
 	 */
 	function createAndAuthenticate(
 		string calldata _name,
@@ -60,7 +83,11 @@ contract PropertyFactory is UsingConfig, IPropertyFactory {
 	}
 
 	/**
-	 * Creates a new Property contract.
+	 * @dev Creates a new Property contract.
+	 * @param _name Name of the new Property.
+	 * @param _symbol Symbol of the new Property.
+	 * @param _author Author address of the new Property.
+	 * @return Address of the new Property.
 	 */
 	function _create(
 		string memory _name,
@@ -82,34 +109,39 @@ contract PropertyFactory is UsingConfig, IPropertyFactory {
 		return address(property);
 	}
 
-	function createChangeAuthorEvent(address _old, address _new) external {
-		require(
-			IPropertyGroup(config().propertyGroup()).isGroup(msg.sender),
-			"this is illegal address"
-		);
-
+	/**
+	 * @dev Emit ChangeAuthor event.
+	 * @param _old The old author of the Property.
+	 * @param _new The new author of the Property.
+	 */
+	function createChangeAuthorEvent(address _old, address _new)
+		external
+		onlyProperty
+	{
 		emit ChangeAuthor(msg.sender, _old, _new);
 	}
 
+	/**
+	 * @dev Emit ChangeName event.
+	 * @param _old The old name of the Property.
+	 * @param _new The new name of the Property.
+	 */
 	function createChangeNameEvent(string calldata _old, string calldata _new)
 		external
+		onlyProperty
 	{
-		require(
-			IPropertyGroup(config().propertyGroup()).isGroup(msg.sender),
-			"this is illegal address"
-		);
-
 		emit ChangeName(msg.sender, _old, _new);
 	}
 
+	/**
+	 * @dev Emit ChangeSymbol event.
+	 * @param _old The symbol name of the Property.
+	 * @param _new The symbol name of the Property.
+	 */
 	function createChangeSymbolEvent(string calldata _old, string calldata _new)
 		external
+		onlyProperty
 	{
-		require(
-			IPropertyGroup(config().propertyGroup()).isGroup(msg.sender),
-			"this is illegal address"
-		);
-
 		emit ChangeSymbol(msg.sender, _old, _new);
 	}
 }

--- a/test/property/property-factory.ts
+++ b/test/property/property-factory.ts
@@ -83,6 +83,7 @@ contract(
 					}
 				)
 				const event = result.logs[0].args
+				expect(result.logs[0].event).to.be.equal('ChangeAuthor')
 				expect(event._property).to.be.equal(dummyProperty)
 				expect(event._beforeAuthor).to.be.equal(beforeAuthor)
 				expect(event._afterAuthor).to.be.equal(afterAuthor)
@@ -96,7 +97,77 @@ contract(
 				const result = await dev.propertyFactory
 					.createChangeAuthorEvent(beforeAuthor, afterAuthor)
 					.catch((err: Error) => err)
-				validateErrorMessage(result, 'this is illegal address')
+				validateErrorMessage(result, 'illegal address')
+			})
+		})
+		describe('PropertyFactory; createChangeNameEvent', () => {
+			it('Emit ChangeName event', async () => {
+				const dev = new DevProtocolInstance(deployer)
+				await dev.generateAddressConfig()
+				await dev.generatePropertyGroup()
+				await dev.addressConfig.setPropertyFactory(dummyProperFactory)
+				await dev.propertyGroup.addGroup(dummyProperty, {
+					from: dummyProperFactory,
+				})
+				await dev.generatePropertyFactory()
+				const result = await dev.propertyFactory.createChangeNameEvent(
+					'old',
+					'new',
+					{
+						from: dummyProperty,
+					}
+				)
+				const event = result.logs[0].args
+				expect(result.logs[0].event).to.be.equal('ChangeName')
+				expect(event._property).to.be.equal(dummyProperty)
+				expect(event._old).to.be.equal('old')
+				expect(event._new).to.be.equal('new')
+			})
+
+			it('should fail to call when the sender is not Property', async () => {
+				const dev = new DevProtocolInstance(deployer)
+				await dev.generateAddressConfig()
+				await dev.generatePropertyGroup()
+				await dev.generatePropertyFactory()
+				const result = await dev.propertyFactory
+					.createChangeNameEvent('old', 'new')
+					.catch((err: Error) => err)
+				validateErrorMessage(result, 'illegal address')
+			})
+		})
+		describe('PropertyFactory; createChangeSymbolEvent', () => {
+			it('Emit ChangeSymbol event', async () => {
+				const dev = new DevProtocolInstance(deployer)
+				await dev.generateAddressConfig()
+				await dev.generatePropertyGroup()
+				await dev.addressConfig.setPropertyFactory(dummyProperFactory)
+				await dev.propertyGroup.addGroup(dummyProperty, {
+					from: dummyProperFactory,
+				})
+				await dev.generatePropertyFactory()
+				const result = await dev.propertyFactory.createChangeSymbolEvent(
+					'old',
+					'new',
+					{
+						from: dummyProperty,
+					}
+				)
+				const event = result.logs[0].args
+				expect(result.logs[0].event).to.be.equal('ChangeSymbol')
+				expect(event._property).to.be.equal(dummyProperty)
+				expect(event._old).to.be.equal('old')
+				expect(event._new).to.be.equal('new')
+			})
+
+			it('should fail to call when the sender is not Property', async () => {
+				const dev = new DevProtocolInstance(deployer)
+				await dev.generateAddressConfig()
+				await dev.generatePropertyGroup()
+				await dev.generatePropertyFactory()
+				const result = await dev.propertyFactory
+					.createChangeSymbolEvent('old', 'new')
+					.catch((err: Error) => err)
+				validateErrorMessage(result, 'illegal address')
 			})
 		})
 		describe('PropertyFactory; createAndAuthenticate', () => {


### PR DESCRIPTION
# Description

I implemented a new feature "Property Renaming" and "Symbol Renaming"

# Why

Properties can be created by non-authors, but their names and symbols cannot be changed later.

Names and symbols that are inconvenient for the author should be able to be changed by the author.

# Related Issues

Fixes # .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
