### PR TITLE
Add a new option `bytes32 _payload` for the staking function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,10 @@
 			"globals": {
 				"artifacts": "readonly",
 				"Truffle": "readonly"
+			},
+			"rules": {
+				"@typescript-eslint/ban-ts-comment": "off",
+				"@typescript-eslint/prefer-ts-expect-error": "off"
 			}
 		}
 	]

--- a/contracts/interface/ILockup.sol
+++ b/contracts/interface/ILockup.sol
@@ -6,6 +6,12 @@ interface ILockup {
 		external
 		returns (uint256);
 
+	function depositToProperty(
+		address _property,
+		uint256 _amount,
+		bytes32 _data
+	) external returns (uint256);
+
 	function depositToPosition(uint256 _tokenId, uint256 _amount)
 		external
 		returns (bool);

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -102,13 +102,31 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 	 */
 	function depositToProperty(address _property, uint256 _amount)
 		external
-		onlyAuthenticatedProperty(_property)
 		returns (uint256)
 	{
-		/**
-		 * Validates _amount is not 0.
-		 */
-		require(_amount != 0, "illegal deposit amount");
+		return _implDepositToProperty(_property, _amount, "");
+	}
+
+	/**
+	 * @dev deposit dev token to dev protocol and generate s-token
+	 * @param _property target property address
+	 * @param _amount staking value
+	 * @param _payload additional bytes for s-token
+	 * @return tokenId The ID of the created new staking position
+	 */
+	function depositToProperty(
+		address _property,
+		uint256 _amount,
+		bytes32 _payload
+	) external returns (uint256) {
+		return _implDepositToProperty(_property, _amount, _payload);
+	}
+
+	function _implDepositToProperty(
+		address _property,
+		uint256 _amount,
+		bytes32 _payload
+	) private onlyAuthenticatedProperty(_property) returns (uint256) {
 		/**
 		 * Gets the latest cumulative sum of the interest price.
 		 */
@@ -145,7 +163,8 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 			msg.sender,
 			_property,
 			_amount,
-			interest
+			interest,
+			_payload
 		);
 		emit Lockedup(msg.sender, _property, _amount);
 		return tokenId;
@@ -1212,7 +1231,8 @@ contract Lockup is ILockup, UsingConfig, LockupStorage {
 			msg.sender,
 			_property,
 			amount,
-			price
+			price,
+			""
 		);
 		/**
 		 * update position information

--- a/contracts/test/token/STokenManagerTest.sol
+++ b/contracts/test/token/STokenManagerTest.sol
@@ -13,6 +13,7 @@ contract STokensManagerTest is ERC721 {
 	address public config;
 	uint256 public latestTokenId;
 	mapping(bytes32 => bytes) private bytesStorage;
+	mapping(uint256 => bytes32) private payloadStorage;
 
 	struct StakingPositionV1 {
 		address property;
@@ -42,7 +43,8 @@ contract STokensManagerTest is ERC721 {
 		address _owner,
 		address _property,
 		uint256 _amount,
-		uint256 _price
+		uint256 _price,
+		bytes32 _payload
 	) external onlyLockup returns (uint256 tokenId_) {
 		_tokenIds.increment();
 		uint256 newTokenId = _tokenIds.current();
@@ -56,7 +58,12 @@ contract STokensManagerTest is ERC721 {
 		);
 		setStoragePositionsV1(newTokenId, newPosition);
 		latestTokenId = newTokenId;
+		payloadStorage[newTokenId] = _payload;
 		return newTokenId;
+	}
+
+	function payloadOf(uint256 _tokenId) external view returns (bytes32) {
+		return payloadStorage[_tokenId];
 	}
 
 	function update(

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"web3": "1.7.4"
 	},
 	"dependencies": {
-		"@devprotocol/i-s-tokens": "1.8.0",
+		"@devprotocol/i-s-tokens": "2.0.0",
 		"@openzeppelin/contracts": "2.5.1"
 	},
 	"directories": {

--- a/test/lockup/lockup-s-token.ts
+++ b/test/lockup/lockup-s-token.ts
@@ -100,7 +100,7 @@ contract('LockupTest', ([deployer, , user2, user3]) => {
 					100,
 					web3.utils.keccak256('ADDITIONAL_BYTES')
 				)
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
 				const payload = await dev.sTokenManager.payloadOf(1)
 				expect(payload).to.be.equal(web3.utils.keccak256('ADDITIONAL_BYTES'))
 			})

--- a/test/lockup/lockup-s-token.ts
+++ b/test/lockup/lockup-s-token.ts
@@ -92,6 +92,23 @@ contract('LockupTest', ([deployer, , user2, user3]) => {
 				expect(position[3].toNumber()).to.be.equal(0)
 				expect(position[4].toNumber()).to.be.equal(0)
 			})
+			it('pass the 3rd option', async () => {
+				await dev.dev.approve(dev.lockup.address, 100)
+				// @ts-ignore
+				await dev.lockup.depositToProperty(
+					property.address,
+					100,
+					web3.utils.keccak256('ADDITIONAL_BYTES')
+				)
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				const payload = await dev.sTokenManager.payloadOf(1)
+				expect(payload).to.be.equal(web3.utils.keccak256('ADDITIONAL_BYTES'))
+			})
+			it('0 dev staking', async () => {
+				await dev.lockup.depositToProperty(property.address, 0)
+				const position = await dev.sTokenManager.positions(1)
+				expect(toBigNumber(position[1]).toNumber()).to.be.equal(0)
+			})
 			it('generate event.', async () => {
 				await dev.dev.approve(dev.lockup.address, 100)
 				dev.lockup.depositToProperty(property.address, 100)
@@ -142,12 +159,6 @@ contract('LockupTest', ([deployer, , user2, user3]) => {
 					.depositToProperty(propertyAddress, 100)
 					.catch(err)
 				validateErrorMessage(res, 'unable to stake to unauthenticated property')
-			})
-			it('0 dev staking is not possible.', async () => {
-				const res = await dev.lockup
-					.depositToProperty(property.address, 0)
-					.catch(err)
-				validateErrorMessage(res, 'illegal deposit amount')
 			})
 			it('user is not holding dev.', async () => {
 				const res = await dev.lockup

--- a/yarn.lock
+++ b/yarn.lock
@@ -142,10 +142,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@devprotocol/i-s-tokens@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@devprotocol/i-s-tokens/-/i-s-tokens-1.8.0.tgz#cdad0c794c235b1091e668e6810cf6919d67318c"
-  integrity sha512-W5uL5DTM8bvseX0Pfm1iFMT4e/0e11cmGnM6QW9tppirgHJBnsvT44wK62v+Q7FRxmupk8KAQQbQV3Ob967Kug==
+"@devprotocol/i-s-tokens@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@devprotocol/i-s-tokens/-/i-s-tokens-2.0.0.tgz#569f82aa73341110cb3e498fad140dcc806c77f0"
+  integrity sha512-r5mpwDu2k5eN2tgGH9+UKJB2L0GPJh88jqbw2ZU1B18hhY/yKsE+S1o8iLxKJcn0JIVowAaDt0hYR4L1DSRSbQ==
 
 "@devprotocol/util-ts@2.2.1":
   version "2.2.1"


### PR DESCRIPTION
Follow https://github.com/dev-protocol/protocol-v2/pull/394

## Todos

- [x] Deploy the new [STokensManager](https://github.com/dev-protocol/s-tokens/pull/216)
- [x] Deploy the new [STokensDescriptor](https://github.com/dev-protocol/s-tokens/pull/216)
- [x] Deploy the new Lockup <br/>`_config = 0x1d415aa39d647834786eb9b5a333a50e9935b796`<br/>`_devMinter = 0x4596DaE6955693C50522F1b06bDBf7b93cEB5479`<br/>`_sTokensManager = 0x50489Ff5f879A44C87bBA85287729D663b18CeD5`
- [x] Call Lockup.setStorage with `0x4a154e51b69A798d854E100fDf79e6f0Be0e330D`
- [x] Call [OldLockup](https://etherscan.io/address/0xbd2a75e11de78af8d58595fb16181d505777804f).changeOwner with the address of the deployed Lockup
- [x] Call [AddressConfig](https://etherscan.io/address/0x1d415aa39d647834786eb9b5a333a50e9935b796).setLockup with the address of the deployed Lockup
- [x] Call [Admin](https://etherscan.io/address/0x8786d9635d3cbe2d07e2b74917548aee77d99cd2).upgrade with `proxy = 0x50489Ff5f879A44C87bBA85287729D663b18CeD5` and `implementation = the address of the deployed STokensManager`
- [x] Call STokensManager.setDescriptor with the address of the deployed STokensDescriptor
